### PR TITLE
NN-1950 Regression - Recurring appointments. 

### DIFF
--- a/src/main/java/net/syscon/elite/api/model/bulkappointments/Repeat.java
+++ b/src/main/java/net/syscon/elite/api/model/bulkappointments/Repeat.java
@@ -1,8 +1,10 @@
 package net.syscon.elite.api.model.bulkappointments;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -12,6 +14,8 @@ import java.util.stream.Stream;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Repeat {
     @ApiModelProperty(required = true, value = "The period at which the appointment should repeat.", example = "WEEKLY", allowableValues = "DAILY, WEEKDAYS, WEEKLY, FORTNIGHTLY, MONTHLY")
     @NotNull

--- a/src/test/java/net/syscon/elite/api/model/bulkappointments/RepeatTest.java
+++ b/src/test/java/net/syscon/elite/api/model/bulkappointments/RepeatTest.java
@@ -134,4 +134,14 @@ public class RepeatTest {
                         LocalDateTime.of(LocalDate.of(2019, 7, 31), START_TIME)
                 );
     }
+
+    @Test
+    public void noArgsConstructor() {
+        new Repeat();
+    }
+
+    @Test
+    public void allArgsConstructor() {
+        new Repeat(RepeatPeriod.DAILY, 1);
+    }
 }


### PR DESCRIPTION
Create no-arg and all-arg constructors for Repeat class (using annotations) and introduce tests for this. (if you can call them tests).  This seems to make the problem go away - but I don't understand why the existing Cucumber tests didn't expose this bug.  Perhaps the docker build differs from the run-time environment in which the cucumber tests are run. I find this ... disconcerting.