### PR TITLE
Enable HMP Kirham for Whereabouts

### DIFF
--- a/src/main/resources/whereabouts/enabled.properties
+++ b/src/main/resources/whereabouts/enabled.properties
@@ -22,3 +22,4 @@ BLI
 CFI
 UKI
 UPI
+KMI


### PR DESCRIPTION
As title - this is to enable HMP Kirham - verified as KMI - to have Whereabouts