### PR TITLE
Enable HMP Thorn Cross for Whereabouts

### DIFF
--- a/src/main/resources/whereabouts/enabled.properties
+++ b/src/main/resources/whereabouts/enabled.properties
@@ -26,3 +26,4 @@ KMI
 FHI
 HLI
 HMI
+TCI


### PR DESCRIPTION
This is to enable HMP Thorn Cross for Whereabouts