### PR TITLE
Enable HMP Lewes for Whereabouts

### DIFF
--- a/src/main/resources/whereabouts/enabled.properties
+++ b/src/main/resources/whereabouts/enabled.properties
@@ -41,3 +41,4 @@ KVI
 DMI
 FKI
 FNI
+LWI


### PR DESCRIPTION
This is to enable HMP Lewes to be able to use Whereabouts