### PR TITLE
PAT-320: Renamed v1 Alert class to AlertV1 to prevent springfox issue.

### DIFF
--- a/src/main/java/net/syscon/elite/api/model/v1/AlertV1.java
+++ b/src/main/java/net/syscon/elite/api/model/v1/AlertV1.java
@@ -20,7 +20,7 @@ import java.time.LocalDate;
 @ToString
 @JsonInclude(Include.NON_NULL)
 @JsonPropertyOrder({"alert_type", "alert_sub_type", "alert_date", "expiry_date", "status", "comment"})
-public class Alert {
+public class AlertV1 {
 
     @ApiModelProperty(value = "Code and description identifying the type of alert", required = true, example = "{ code: 'X', desc: 'Security' }")
     @JsonProperty("alert_type")

--- a/src/main/java/net/syscon/elite/api/model/v1/Alerts.java
+++ b/src/main/java/net/syscon/elite/api/model/v1/Alerts.java
@@ -14,5 +14,5 @@ import java.util.List;
 @ToString
 public class Alerts {
     @ApiModelProperty(value = "Alerts", allowEmptyValue = true)
-    private List<Alert> alerts;
+    private List<AlertV1> alerts;
 }

--- a/src/main/java/net/syscon/elite/service/v1/NomisApiV1Service.java
+++ b/src/main/java/net/syscon/elite/service/v1/NomisApiV1Service.java
@@ -109,10 +109,10 @@ public class NomisApiV1Service {
                 .build();
     }
 
-    public List<Alert> getAlerts(final String nomsId, final boolean includeInactive, final LocalDateTime modifiedSince) {
+    public List<AlertV1> getAlerts(final String nomsId, final boolean includeInactive, final LocalDateTime modifiedSince) {
         final var alerts = alertV1Repository.getAlerts(nomsId, includeInactive, modifiedSince).stream()
                 .filter(a -> a.getAlertSeq() != null)
-                .map(a -> Alert.builder()
+                .map(a -> AlertV1.builder()
                         .type(CodeDescription.safeNullBuild(a.getAlertType(), a.getAlertTypeDesc()))
                         .subType(CodeDescription.safeNullBuild(a.getAlertCode(), a.getAlertCodeDesc()))
                         .date(a.getAlertDate())


### PR DESCRIPTION
Springfox was generating swagger docs incorrectly. See issue https://github.com/springfox/springfox/issues/182 - where the package is ignored for classes with the same name which caused /api/bookings/{bookingId} to incorrectly show the alert structure for model/v1/Alert.java, not model/Alert.java in its alerts output.