### PR TITLE
DT-501 small addition for running spring boot with commandline args

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -30,9 +30,15 @@
 
 2) Using Gradle directly via command-line (optionally setting the spring profile variable to select the in-memory database)
 
+*Windows*
 ```bash
 set JAVA_OPTS=-Dspring.profiles.active=nomis-hsqldb
 gradlew bootRun
+```
+
+*Mac*
+```bash
+./gradlew bootRun --args='--spring.profiles.active=nomis-hsqldb'
 ```
 
 #### Health


### PR DESCRIPTION
Small addition to the docs support running the elite spring boot app on Mac.