### PR TITLE
DT-497 Adding springfox-bean-validators plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,8 @@ dependencies {
 
     implementation 'io.springfox:springfox-swagger-ui:2.9.2'
     implementation 'io.springfox:springfox-swagger2:2.9.2'
+    implementation 'io.springfox:springfox-bean-validators:2.9.2'
+
     implementation 'net.logstash.logback:logstash-logback-encoder:6.3'
     implementation 'com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.0-BETA'
     implementation 'com.microsoft.azure:applicationinsights-logging-logback:2.6.0-BETA'

--- a/src/main/java/net/syscon/elite/api/model/v1/AlertV1.java
+++ b/src/main/java/net/syscon/elite/api/model/v1/AlertV1.java
@@ -22,11 +22,11 @@ import java.time.LocalDate;
 @JsonPropertyOrder({"alert_type", "alert_sub_type", "alert_date", "expiry_date", "status", "comment"})
 public class AlertV1 {
 
-    @ApiModelProperty(value = "Code and description identifying the type of alert", required = true, example = "{ code: 'X', desc: 'Security' }")
+    @ApiModelProperty(value = "Code and description identifying the type of alert", required = true, example = "{ \"code\": \"FX\", \"desc\": \"Security\" }")
     @JsonProperty("alert_type")
     private CodeDescription type;
 
-    @ApiModelProperty(value = "Code and description identifying the sub type of alert", position = 1, required = true, example = "{ code: 'XEL', desc: 'Escape List' }")
+    @ApiModelProperty(value = "Code and description identifying the sub type of alert", position = 1, required = true, example = "{ \"code\": \"XEL\", \"desc\": \"Escape List\" }")
     @JsonProperty("alert_sub_type")
     private CodeDescription subType;
 

--- a/src/main/java/net/syscon/elite/api/model/v1/Charge.java
+++ b/src/main/java/net/syscon/elite/api/model/v1/Charge.java
@@ -22,10 +22,10 @@ public class Charge {
     @JsonIgnore
     private Long offenderChargeId;
 
-    @ApiModelProperty(value = "Statute", position = 1, example = "{ code: 'PL96', desc: 'Police Act 1996' }")
+    @ApiModelProperty(value = "Statute", position = 1, example = "{ \"code\": \"PL96\", \"desc\": \"Police Act 1996\" }")
     private CodeDescription statute;
 
-    @ApiModelProperty(value = "Offence", position = 2, example = "{ code: 'PL96001', desc: 'Assault a constable in the execution of his / her duty' }")
+    @ApiModelProperty(value = "Offence", position = 2, example = "{ \"code\": \"PL96001\", \"desc\": \"Assault a constable in the execution of his / her duty\" }")
     private CodeDescription offence;
 
     @ApiModelProperty(value = "Number of Offences", position = 3, example = "2")
@@ -44,20 +44,20 @@ public class Charge {
     @JsonProperty("severity_ranking")
     private String severityRanking;
 
-    @ApiModelProperty(value = "Result", position = 7, example = "{ code: '1002', desc: 'Imprisonment' }")
+    @ApiModelProperty(value = "Result", position = 7, example = "{ \"code\": \"1002\", \"desc\": \"Imprisonment\" }")
     private CodeDescription result;
 
-    @ApiModelProperty(value = "Disposition", position = 8, example = "{ code: 'F', desc: 'Final' }")
+    @ApiModelProperty(value = "Disposition", position = 8, example = "{ \"code\": \"F\", \"desc\": \"Final\" }")
     private CodeDescription disposition;
 
     @ApiModelProperty(value = "Convicted", position = 9, example = "true")
     private boolean convicted;
 
-    @ApiModelProperty(value = "Imprisonment Status", position = 10, example = "{ code: 'UNK_SENT', desc: 'Unknown Sentenced' }")
+    @ApiModelProperty(value = "Imprisonment Status", position = 10, example = "{ \"code\": \"UNK_SENT\", \"desc\": \"Unknown Sentenced\" }")
     @JsonProperty("imprisonment_status")
     private CodeDescription imprisonmentStatus;
 
-    @ApiModelProperty(value = "Band", position = 11, example = "{ code: '1', desc: 'Sent-Determinate NonFine' }")
+    @ApiModelProperty(value = "Band", position = 11, example = "{ \"code\": \"1\", \"desc\": \"Sent-Determinate NonFine\" }")
     private CodeDescription band;
 
 

--- a/src/main/java/net/syscon/elite/api/model/v1/LegalCase.java
+++ b/src/main/java/net/syscon/elite/api/model/v1/LegalCase.java
@@ -38,10 +38,10 @@ public class LegalCase {
     @JsonProperty("case_started")
     private LocalDate beginDate;
 
-    @ApiModelProperty(value = "Court", position = 4, example = "{ code: 'ABDRCT', desc: 'Aberdare County Court' }")
+    @ApiModelProperty(value = "Court", position = 4, example = "{ \"code\": \"ABDRCT\", \"desc\": \"Aberdare County Court\" }")
     private CodeDescription court;
 
-    @ApiModelProperty(value = "Legal Case Type", position = 5, example = "{ code: 'A', desc: 'Adult' }")
+    @ApiModelProperty(value = "Legal Case Type", position = 5, example = "{ \"code\": \"A\", \"desc\": \"Adult\" }")
     @JsonProperty("legal_case_type")
     private CodeDescription caseType;
 

--- a/src/main/java/net/syscon/elite/web/config/SwaggerConfig.java
+++ b/src/main/java/net/syscon/elite/web/config/SwaggerConfig.java
@@ -7,7 +7,9 @@ import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
 import springfox.documentation.builders.AuthorizationCodeGrantBuilder;
 import springfox.documentation.builders.OAuthBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -26,6 +28,7 @@ import static springfox.documentation.builders.PathSelectors.regex;
 
 @Configuration
 @EnableSwagger2
+@Import(BeanValidatorPluginsConfiguration.class)
 public class SwaggerConfig {
 
     @Autowired(required = false)


### PR DESCRIPTION
This picks up javax validation annotations and enriches produced swagger doc with additional validation info.

Also dodgy examples was meaning swagger.json was invalid so fixed them.
 