### PR TITLE
DT-526 Add temporary endpoint to trial future replacement service

### DIFF
--- a/src/main/java/net/syscon/elite/api/resource/AgencyResource.java
+++ b/src/main/java/net/syscon/elite/api/resource/AgencyResource.java
@@ -92,6 +92,19 @@ public interface AgencyResource {
             @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
     List<LocationGroup> getAvailableLocationGroups(@ApiParam(value = "The prison", required = true) @PathVariable("agencyId") String agencyId);
 
+    /**
+     * TODO DT-526 Delete .../locations/groupsNew once the new endpoint has been tested from whereabouts API and prisonstaffhub
+     *      UI has been changed to no longer point to this API (replaced with call to whereabouts API).
+     */
+    @GetMapping("/{agencyId}/locations/groupsNew")
+    @ApiOperation(value = "List of all available Location Groups at agency.", notes = "List of all available Location Groups at agency.", nickname = "getAvailableLocationGroupsNew")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK", response = LocationGroup.class, responseContainer = "List"),
+            @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
+            @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
+            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
+    List<LocationGroup> getAvailableLocationGroupsNew(@ApiParam(value = "The prison", required = true) @PathVariable("agencyId") String agencyId);
+
 
     @GetMapping("/{agencyId}/locations/whereabouts")
     @ApiOperation(value = "Whereabouts details (e.g. whether enabled) for prison.", notes = "Whereabouts details (e.g. whether enabled) for prison.", nickname = "getWhereabouts")

--- a/src/main/java/net/syscon/elite/api/resource/impl/AgencyResourceImpl.java
+++ b/src/main/java/net/syscon/elite/api/resource/impl/AgencyResourceImpl.java
@@ -18,19 +18,28 @@ import static net.syscon.elite.repository.support.StatusFilter.ACTIVE_ONLY;
 import static net.syscon.elite.repository.support.StatusFilter.ALL;
 import static net.syscon.util.ResourceUtils.nvl;
 
+/**
+ * TODO DT-526 Replace locationGroupService with newLocationGroupService once the new endpoint has been tested from whereabouts
+ *      API and prisonstaffhub UI has been changed to no longer point to this API (replaced with call to whereabouts API).
+ *      At the same time LocationGroupServiceSelector and LocationGroupFromDbService can be deleted.
+ */
+
 @RestController
 @RequestMapping("${api.base.path}/agencies")
 public class AgencyResourceImpl implements AgencyResource {
     private final AgencyService agencyService;
     private final LocationGroupService locationGroupService;
+    private final LocationGroupService newLocationGroupService;
     private final WhereaboutsEnabledService whereaboutsEnabledService;
 
     public AgencyResourceImpl(
             final AgencyService agencyService,
             @Qualifier("locationGroupServiceSelector") final LocationGroupService locationGroupService,
+            @Qualifier("defaultLocationGroupService") final LocationGroupService newLocationGroupService,
             WhereaboutsEnabledService whereaboutsEnabledService) {
         this.agencyService = agencyService;
         this.locationGroupService = locationGroupService;
+        this.newLocationGroupService = newLocationGroupService;
         this.whereaboutsEnabledService = whereaboutsEnabledService;
     }
 
@@ -61,6 +70,11 @@ public class AgencyResourceImpl implements AgencyResource {
     @Override
     public List<LocationGroup> getAvailableLocationGroups(final String agencyId) {
         return locationGroupService.getLocationGroupsForAgency(agencyId);
+    }
+
+    @Override
+    public List<LocationGroup> getAvailableLocationGroupsNew(final String agencyId) {
+        return newLocationGroupService.getLocationGroupsForAgency(agencyId);
     }
 
     @Override

--- a/src/test/java/net/syscon/elite/api/resource/impl/AgencyResourceImplIntTest.java
+++ b/src/test/java/net/syscon/elite/api/resource/impl/AgencyResourceImplIntTest.java
@@ -1,0 +1,63 @@
+package net.syscon.elite.api.resource.impl;
+
+
+import net.syscon.elite.api.model.ErrorResponse;
+import net.syscon.elite.api.model.Location;
+import net.syscon.elite.api.model.LocationGroup;
+import net.syscon.elite.repository.LocationRepository;
+import net.syscon.elite.service.EntityNotFoundException;
+import net.syscon.elite.service.LocationGroupService;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * TODO DT-526 Replace calls to .../locations/groupsNew with .../locations/groups once the new endpoint has been tested from whereabouts
+ *      API and prisonstaffhub UI has been changed to no longer point to this API (replaced with call to whereabouts API).
+ */
+
+public class AgencyResourceImplIntTest extends ResourceTest {
+
+    private final Location L1 = Location.builder().locationId(-1L).locationType("WING").description("LEI-A").userDescription("BLOCK A").internalLocationCode("A").build();
+
+    @MockBean
+    private LocationRepository repository;
+
+    @SpyBean
+    @Qualifier("defaultLocationGroupService")
+    private LocationGroupService locationGroupService;
+
+    @Test
+    public void locationGroups_allOk_returnsSuccessAndData() {
+        when(repository.getLocationGroupData("LEI")).thenReturn(List.of(L1));
+
+        final var requestEntity = createHttpEntityWithBearerAuthorisation("ITAG_USER", List.of(), Map.of());
+
+        final var responseEntity = testRestTemplate.exchange("/api/agencies/LEI/locations/groupsNew", HttpMethod.GET, requestEntity, new ParameterizedTypeReference<List<LocationGroup>>() {});
+
+        assertThatStatus(responseEntity, 200);
+        assertThat(responseEntity.getBody()).containsExactly(LocationGroup.builder().key("A").name("Block A").build());
+
+    }
+
+    @Test
+    public void locationGroups_randomError_returnsErrorFromControllerAdvice() {
+        when(locationGroupService.getLocationGroups("LEI")).thenThrow(new EntityNotFoundException("test ex"));
+
+        final var requestEntity = createHttpEntityWithBearerAuthorisation("ITAG_USER", List.of(), Map.of());
+
+        final var responseEntity = testRestTemplate.exchange("/api/agencies/LEI/locations/groupsNew", HttpMethod.GET, requestEntity, ErrorResponse.class);
+
+        assertThatStatus(responseEntity, 404);
+        assertThat(responseEntity.getBody().getUserMessage()).isEqualTo("test ex");
+    }
+}


### PR DESCRIPTION
The endgame is to move the LocationGroupServiceSelector and the
LocationGroupServiceFromProperties to the Whereabouts API and just leave
the LocationGroupServiceFromDB in this service.  The new endpoint uses
only LocationGroupServiceFromDB so we can trial the changes before
turning them on in production.