### PR TITLE
Re-purposing endpoint for agency by type lookup.

### DIFF
--- a/src/main/java/net/syscon/elite/api/resource/AgencyResource.java
+++ b/src/main/java/net/syscon/elite/api/resource/AgencyResource.java
@@ -29,7 +29,7 @@ public interface AgencyResource {
     ResponseEntity<List<Agency>> getAgencies(@ApiParam(value = "Requested offset of first record in returned collection of agency records.", defaultValue = "0") @RequestHeader(value = "Page-Offset", defaultValue = "0", required = false) Long pageOffset,
                                     @ApiParam(value = "Requested limit to number of agency records returned.", defaultValue = "10") @RequestHeader(value = "Page-Limit", defaultValue = "10", required = false) Long pageLimit);
 
-    @GetMapping("/by-type/{type}")
+    @GetMapping("/type/{type}")
     @ApiOperation(value = "List of agencies by type", notes = "List of active agencies by type")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = Agency.class, responseContainer = "List"),

--- a/src/test/java/net/syscon/elite/api/resource/impl/AgencyResourceTest.java
+++ b/src/test/java/net/syscon/elite/api/resource/impl/AgencyResourceTest.java
@@ -4,9 +4,6 @@ import net.syscon.elite.executablespecification.steps.AuthTokenHelper.AuthToken;
 import org.junit.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-
-import java.util.Map;
 
 public class AgencyResourceTest extends ResourceTest {
 
@@ -17,7 +14,7 @@ public class AgencyResourceTest extends ResourceTest {
         final var httpEntity = createHttpEntity(token, null);
 
         final var response = testRestTemplate.exchange(
-                "/api/agencies/by-type/INST",
+                "/api/agencies/type/INST",
                 HttpMethod.GET,
                 httpEntity,
                 new ParameterizedTypeReference<String>() {
@@ -33,7 +30,7 @@ public class AgencyResourceTest extends ResourceTest {
         final var httpEntity = createHttpEntity(token, null);
 
         final var response = testRestTemplate.exchange(
-                "/api/agencies/by-type/INST?activeOnly={activeOnly}",
+                "/api/agencies/type/INST?activeOnly={activeOnly}",
                 HttpMethod.GET,
                 httpEntity,
                 new ParameterizedTypeReference<String>() {


### PR DESCRIPTION
Small change to endpoint re-purpose `/by-type/` to` /type/`.

Endpoint is very new (unused at moment) so will not affect any consumers.