### PR TITLE
GDPR-160 Renaming field in SQS event

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/nomis/datacompliance/events/publishers/dto/OffenderPendingDeletion.java
+++ b/src/main/java/uk/gov/justice/hmpps/nomis/datacompliance/events/publishers/dto/OffenderPendingDeletion.java
@@ -54,8 +54,8 @@ public class OffenderPendingDeletion {
     private LocalDate birthDate;
 
     @Singular
-    @JsonProperty("offenders")
-    private List<OffenderWithBookings> offenders;
+    @JsonProperty("offenderAliases")
+    private List<OffenderAlias> offenderAliases;
 
     @Getter
     @Builder
@@ -63,7 +63,7 @@ public class OffenderPendingDeletion {
     @EqualsAndHashCode
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class OffenderWithBookings {
+    public static class OffenderAlias {
 
         @JsonProperty("offenderId")
         private Long offenderId;

--- a/src/main/java/uk/gov/justice/hmpps/nomis/datacompliance/service/DataComplianceReferralService.java
+++ b/src/main/java/uk/gov/justice/hmpps/nomis/datacompliance/service/DataComplianceReferralService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.DataComplianceEventPusher;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.Booking;
-import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderWithBookings;
+import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderAlias;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletionReferralComplete;
 import uk.gov.justice.hmpps.nomis.datacompliance.repository.jpa.model.OffenderAliasPendingDeletion;
 import uk.gov.justice.hmpps.nomis.datacompliance.repository.jpa.model.OffenderChargePendingDeletion;
@@ -99,14 +99,14 @@ public class DataComplianceReferralService {
                 .middleName(rootOffenderAlias.getMiddleName())
                 .lastName(rootOffenderAlias.getLastName())
                 .birthDate(rootOffenderAlias.getBirthDate())
-                .offenders(offenderAliases.stream()
+                .offenderAliases(offenderAliases.stream()
                         .map(this::transform)
                         .collect(toUnmodifiableList()))
                 .build();
     }
 
-    private OffenderWithBookings transform(final OffenderAliasPendingDeletion alias) {
-        return OffenderWithBookings.builder()
+    private OffenderAlias transform(final OffenderAliasPendingDeletion alias) {
+        return OffenderAlias.builder()
                 .offenderId(alias.getOffenderId())
                 .bookings(alias.getOffenderBookings().stream()
                         .map(booking -> Booking.builder()

--- a/src/test/java/uk/gov/justice/hmpps/nomis/datacompliance/controller/DataComplianceControllerTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/nomis/datacompliance/controller/DataComplianceControllerTest.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.PageRequest;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.DataComplianceEventPusher;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.Booking;
-import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderWithBookings;
+import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderAlias;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletionReferralComplete;
 import uk.gov.justice.hmpps.nomis.datacompliance.service.DataComplianceReferralService;
 import uk.gov.justice.hmpps.prison.api.model.PendingDeletionRequest;
@@ -62,7 +62,7 @@ public class DataComplianceControllerTest extends ResourceTest {
                         .firstName("BURT")
                         .lastName("REYNOLDS")
                         .birthDate(LocalDate.of(1966, 1, 1))
-                        .offender(OffenderWithBookings.builder()
+                        .offenderAlias(OffenderAlias.builder()
                                 .offenderId(-1020L)
                                 .booking(Booking.builder()
                                         .offenderBookId(-20L)

--- a/src/test/java/uk/gov/justice/hmpps/nomis/datacompliance/events/publishers/DataComplianceEventPusherTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/nomis/datacompliance/events/publishers/DataComplianceEventPusherTest.java
@@ -15,7 +15,7 @@ import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.FreeTextS
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderDeletionComplete;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.Booking;
-import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderWithBookings;
+import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderAlias;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletionReferralComplete;
 
 import java.time.LocalDate;
@@ -54,7 +54,7 @@ class DataComplianceEventPusherTest {
                 .middleName("Middle")
                 .lastName("Jones")
                 .birthDate(LocalDate.of(1990, 1, 2))
-                .offender(OffenderWithBookings.builder()
+                .offenderAlias(OffenderAlias.builder()
                         .offenderId(123L)
                         .booking(Booking.builder()
                                 .offenderBookId(321L)
@@ -71,7 +71,7 @@ class DataComplianceEventPusherTest {
                         "\"middleName\":\"Middle\"," +
                         "\"lastName\":\"Jones\"," +
                         "\"birthDate\":\"1990-01-02\"," +
-                        "\"offenders\":[{" +
+                        "\"offenderAliases\":[{" +
                             "\"offenderId\":123,\"bookings\":[{\"offenderBookId\":321,\"offenceCodes\":[\"offence1\"]}]" +
                         "}]" +
                 "}");

--- a/src/test/java/uk/gov/justice/hmpps/nomis/datacompliance/service/DataComplianceReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/nomis/datacompliance/service/DataComplianceReferralServiceTest.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.DataComplianceEventPusher;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.Booking;
-import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderWithBookings;
+import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletion.OffenderAlias;
 import uk.gov.justice.hmpps.nomis.datacompliance.events.publishers.dto.OffenderPendingDeletionReferralComplete;
 import uk.gov.justice.hmpps.nomis.datacompliance.repository.jpa.model.OffenderAliasPendingDeletion;
 import uk.gov.justice.hmpps.nomis.datacompliance.repository.jpa.model.OffenderBookingPendingDeletion;
@@ -125,7 +125,7 @@ public class DataComplianceReferralServiceTest {
                 .middleName("Middle" + offenderId)
                 .lastName("Smith" + offenderId)
                 .birthDate(LocalDate.of(2020, 1, (int) offenderId))
-                .offender(OffenderWithBookings.builder()
+                .offenderAlias(OffenderAlias.builder()
                         .offenderId(offenderId)
                         .booking(Booking.builder()
                                 .offenderBookId(offenderId)


### PR DESCRIPTION
Renaming to be a bit more explicit - an offender record can
have multiple entries in the OFFENDERS table which are
aliases for the same person and have their own offender id.