### PR TITLE
DT-1265 ⚡️Changed getLatestBookingByOffenderNo and getLatestBookingBy…

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderResource.java
@@ -325,7 +325,6 @@ public class OffenderResource {
     @GetMapping("/{offenderNo}/iepSummary")
     public PrivilegeSummary getLatestBookingIEPSummaryForOffender(@NotNull @PathVariable("offenderNo") @ApiParam(value = "offenderNo", required = true, example = "A1234AA") final String offenderNo, @RequestParam(value = "withDetails", required = false, defaultValue = "false") @ApiParam(value = "Toggle to return IEP detail entries in response (or not).", required = true) final boolean withDetails) {
         var booking = bookingService.getLatestBookingByOffenderNo(offenderNo);
-        Optional.ofNullable(booking).orElseThrow(EntityNotFoundException.withId(offenderNo));
         return bookingService.getBookingIEPSummary(booking.getBookingId(), withDetails);
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -556,12 +556,12 @@ public class BookingService {
 
     // FOR INTERNAL USE - ONLY CALL FROM SERVICE LAYER
     public OffenderSummary getLatestBookingByBookingId(final Long bookingId) {
-        return bookingRepository.getLatestBookingByBookingId(bookingId).orElse(null);
+        return bookingRepository.getLatestBookingByBookingId(bookingId).orElseThrow(EntityNotFoundException.withId(bookingId));
     }
 
     // FOR INTERNAL USE - ONLY CALL FROM SERVICE LAYER
     public OffenderSummary getLatestBookingByOffenderNo(final String offenderNo) {
-        return bookingRepository.getLatestBookingByOffenderNo(offenderNo).orElse(null);
+        return bookingRepository.getLatestBookingByOffenderNo(offenderNo).orElseThrow(EntityNotFoundException.withId(offenderNo));
     }
 
 

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import uk.gov.justice.hmpps.prison.api.model.Alert;
 import uk.gov.justice.hmpps.prison.api.model.AlertChanges;
@@ -94,6 +95,25 @@ public class BookingResourceIntTest extends ResourceTest {
                 -2, -11);
 
         assertThat(response.getStatusCodeValue()).isEqualTo(201);
+    }
+    @Test
+    public void testUpdateAttendance_WithInvalidBookingId(){
+        final var token = authTokenHelper.getToken(AuthToken.PAY);
+        final var body = Map.of("eventOutcome", "ATT", "performance", "STANDARD");
+        final var request = createHttpEntity(token, body);
+
+        final var response = testRestTemplate.exchange(
+                "/api/bookings/{bookingId}/activities/{activityId}/attendance",
+                HttpMethod.PUT,
+                request,
+                ErrorResponse.class,0,-11);
+
+        assertThat(response.getBody()).isEqualTo(
+                ErrorResponse.builder()
+                        .status(404)
+                        .userMessage("Resource with id [0] not found.")
+                        .developerMessage("Resource with id [0] not found.")
+                        .build());
     }
 
     @Test


### PR DESCRIPTION
Updated `getLatestBookingByBookingId` and `getLatestBookingByOffenderNo throw EntityNotFound instead of null when entity not found

Added a new IT tests for getLatestBookingByBookingId(), for non existent bookingId

There is an existing IT test(in class OffenderResourceImplIntTest_getLatestBookingIEPSummaryForOffender)  for getLatestBookingByOffenderNo, for non existent offenderId  
