### PR TITLE
NN-3178: Ensure Case Notes cannot exceed 4000 bytes

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/NewCaseNote.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/NewCaseNote.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import uk.gov.justice.hmpps.prison.util.OracleVarcharUtil;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -106,7 +107,7 @@ public class NewCaseNote {
     }
 
     public void setText(final String text) {
-        this.text = text;
+        this.text = OracleVarcharUtil.enforceMaximumTextSize(text);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/hmpps/prison/util/OracleVarcharUtil.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/util/OracleVarcharUtil.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.hmpps.prison.util;
+
+import com.google.common.base.Utf8;
+
+import java.nio.charset.StandardCharsets;
+
+public class OracleVarcharUtil {
+
+    private static int MAX_VARCHAR_SIZE_CHECK_THRESHOLD = 3950;
+    private static int MAX_VARCHAR_SIZE = 4000;
+
+    /**
+     * Ensures the given string does not exceed the limit on characters in an Oracle DB (otherwise we get ORA-01461 errors).
+     * This is required in addition to the 4000 character validation as it may exceed that when unicode encoding is applied.
+     */
+    public static String enforceMaximumTextSize(final String inputText) {
+        String truncatedText = inputText;
+        if (inputText.length() > MAX_VARCHAR_SIZE_CHECK_THRESHOLD) {
+            if (Utf8.encodedLength(inputText) > MAX_VARCHAR_SIZE) {
+                truncatedText = truncateUtf8String(inputText, MAX_VARCHAR_SIZE);
+            }
+        }
+        return truncatedText;
+    }
+
+    private static String truncateUtf8String(final String inputText, final int maximumOutputSize) {
+        // The simplest and most performant solution is to convert the characters from unicode to ASCII
+        byte[] originalBytes = inputText.getBytes(StandardCharsets.US_ASCII);
+        return new String(originalBytes);
+    }
+}

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/model/NewCaseNoteTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/model/NewCaseNoteTest.java
@@ -1,0 +1,30 @@
+package uk.gov.justice.hmpps.prison.api.model;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NewCaseNoteTest {
+
+    private static final String CHAR_TEXT_OVER_4000_BYTES;
+
+    static {
+        String stringWith10Chars = "ABCDE12345";
+        StringBuilder string = new StringBuilder(4010);
+        IntStream.rangeClosed(1,399).forEach((i) -> string.append(stringWith10Chars));
+        string.append("ABCDE123⌘⌥"); // Add Unicode chars
+        CHAR_TEXT_OVER_4000_BYTES = string.toString();
+    }
+
+    @Test
+    public void textCannotExceed4000UTF8Bytes() {
+        var caseNote = new NewCaseNote();
+        caseNote.setText(CHAR_TEXT_OVER_4000_BYTES);
+        assertThat(caseNote.getText().getBytes(StandardCharsets.UTF_8).length).isEqualTo(4000);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/hmpps/prison/util/OracleVarcharUtilTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/util/OracleVarcharUtilTest.java
@@ -1,0 +1,45 @@
+package uk.gov.justice.hmpps.prison.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OracleVarcharUtilTest {
+
+    private static final String CHAR_TEXT_3990_BYTES;
+
+    static {
+        String stringWith10Chars = "ABCDE12345";
+        StringBuilder string = new StringBuilder(4010);
+        IntStream.rangeClosed(1,399).forEach((i) -> string.append(stringWith10Chars));
+        CHAR_TEXT_3990_BYTES = string.toString();
+    }
+
+    @Test
+    public void When_0Bytes_Then_ReturnsUnchanged() {
+        final String testString = "";
+        String treatedString = OracleVarcharUtil.enforceMaximumTextSize(testString);
+        assertThat(treatedString).isEqualTo(testString);
+    }
+
+    @Test
+    public void When_4000BytesIncludingUTF_Then_ReturnsUnchangedWith4000Bytes() {
+        final String testString = CHAR_TEXT_3990_BYTES + "ABCDE12⌥";
+        String treatedString = OracleVarcharUtil.enforceMaximumTextSize(testString);
+        assertThat(treatedString).isEqualTo(testString);
+        assertThat(treatedString.getBytes(StandardCharsets.UTF_8).length).isEqualTo(4000);
+    }
+
+    @Test
+    public void When_Over4000BytesIncludingUTF_Then_ReturnsWithASCIIInPlaceOfUTF() {
+        final String testString = CHAR_TEXT_3990_BYTES + "ABCDE12⌥⌘";
+        final String expectedTreatedString = CHAR_TEXT_3990_BYTES + "ABCDE12??";
+        String treatedString = OracleVarcharUtil.enforceMaximumTextSize(testString);
+        assertThat(treatedString).isEqualTo(expectedTreatedString);
+        assertThat(treatedString.getBytes(StandardCharsets.UTF_8).length).isEqualTo(testString.length());
+    }
+
+}


### PR DESCRIPTION
The problem is that the NewCaseNote.text @Size(max = 4000) annotation does not cater for unicode characters. If the user enters a 4000 char string with a single Unicode char then we see the SQL error.

The most obvious solution is to improve the validation by writing a new annotation. However that will still lead to 500s as the prisonstaffhub does not handle validation errors.

The solution in this PR prevents 500's from being thrown at the cost of replacing the Unicode characters with "?".

Secondly, I have only fixed the problem for new case notes. The problem will still exist when updating case notes. There are many other places where the 4000 char limit will have similar problems, but they are all comment fields that are unlikely to ever reach 4000 chars.