### PR TITLE
✨ PPD-133: Adding endpoint to search users by email address

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/UserResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/UserResource.java
@@ -316,6 +316,14 @@ public class UserResource {
     }
 
     @ApiResponses({
+        @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
+    @ApiOperation(value = "User details for supplied email address", notes = "User details for supplied email address", nickname = "getUserDetailsByEmail")
+    @GetMapping("/email/{emailAddress}")
+    public List<UserDetail> getUserDetailsByEmail(@PathVariable("emailAddress") @ApiParam(value = "The email address of the user.", required = true) final String emailAddress) {
+        return userService.getUsersByEmail(emailAddress);
+    }
+
+    @ApiResponses({
             @ApiResponse(code = 200, message = "OK", response = AccessRole.class, responseContainer = "List"),
             @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
             @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/UserRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/UserRepository.java
@@ -62,6 +62,10 @@ public class UserRepository extends RepositoryBase {
         return Optional.ofNullable(userDetails);
     }
 
+    public List<UserDetail> findByEmailAddress(final String emailAddress) {
+        final var sql = UserRepositorySql.FIND_USER_BY_EMAIL_ADDRESS.getSql();
+        return jdbcTemplate.query(sql, createParams("emailAddress", emailAddress), USER_DETAIL_ROW_MAPPER);
+    }
 
     @Cacheable("findRolesByUsername")
     public List<UserRole> findRolesByUsername(final String username, final String query) {

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/sql/UserRepositorySql.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/sql/UserRepositorySql.kt
@@ -47,6 +47,31 @@ enum class UserRepositorySql(val sql: String) {
     """
   ),
 
+  FIND_USER_BY_EMAIL_ADDRESS(
+    """
+        SELECT SM.STAFF_ID,
+        AUA.USERNAME,
+        SM.FIRST_NAME,
+        SM.LAST_NAME,
+        AUA.WORKING_CASELOAD_ID AS ACTIVE_CASE_LOAD_ID,
+        SM.STATUS ACCOUNT_STATUS,
+        (
+          SELECT TAG_IMAGE_ID
+          FROM TAG_IMAGES
+          WHERE IMAGE_OBJECT_ID = SM.STAFF_ID
+          AND IMAGE_OBJECT_TYPE = 'STAFF'
+          AND ACTIVE_FLAG = 'Y'
+        ) THUMBNAIL_ID
+        FROM STAFF_MEMBERS SM 
+        JOIN STAFF_USER_ACCOUNTS AUA 
+        ON SM.STAFF_ID = AUA.STAFF_ID
+        JOIN INTERNET_ADDRESSES IA
+        ON SM.STAFF_ID = IA.OWNER_ID
+        AND IA.OWNER_CLASS = 'STF'
+        AND IA.INTERNET_ADDRESS = :emailAddress
+    """
+  ),
+
   FIND_ROLES_BY_USERNAME(
     """
         SELECT RL.ROLE_ID,

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/UserService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/UserService.java
@@ -21,6 +21,7 @@ import uk.gov.justice.hmpps.prison.api.support.PageRequest;
 import uk.gov.justice.hmpps.prison.repository.UserRepository;
 import uk.gov.justice.hmpps.prison.security.AuthenticationFacade;
 import uk.gov.justice.hmpps.prison.service.filters.NameFilter;
+import uk.gov.justice.hmpps.prison.util.EmailHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -83,6 +84,17 @@ public class UserService {
             });
         }
         return results;
+    }
+
+    public List<UserDetail> getUsersByEmail(final String emailAddress) {
+        final var userDetails = userRepository.findByEmailAddress(EmailHelper.format(emailAddress));
+        for (UserDetail userDetail: userDetails) {
+          final var caseLoadsForUser = caseLoadService.getCaseLoadsForUser(userDetail.getUsername(), false);
+          if (userDetail.getActiveCaseLoadId() == null && (caseLoadsForUser.isEmpty() || caseLoadsForUser.get(0).equals(EMPTY_CASELOAD))) {
+              userDetail.setActiveCaseLoadId(EMPTY_CASELOAD.getCaseLoadId());
+          }
+        }
+        return userDetails;
     }
 
     @Transactional

--- a/src/main/java/uk/gov/justice/hmpps/prison/util/EmailHelper.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/util/EmailHelper.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.hmpps.prison.util;
+
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public class EmailHelper {
+    public static String format(final String emailInput) {
+        return StringUtils.replaceChars(StringUtils.lowerCase(StringUtils.trim(emailInput)), '’', '\'');
+    }
+}

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/UserRepositoryTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/UserRepositoryTest.java
@@ -50,6 +50,16 @@ public class UserRepositoryTest {
         assertThat(user).isNotPresent();
     }
 
+    @Test
+    public void testFindUserByEmailAddress() {
+        final var users = userRepository.findByEmailAddress("prison-api-user@test.com");
+        assertThat(users).extracting(UserDetail::getLastName).containsOnly("User");
+    }
+
+    @Test
+    public void testFindUserByEmailAddressNotExists() {
+        assertThat(userRepository.findByEmailAddress("XXXXXXXX")).isEmpty();
+    }
 
     @Test
     public void testFindRolesByUsername() {

--- a/src/test/java/uk/gov/justice/hmpps/prison/util/EmailHelperTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/util/EmailHelperTest.java
@@ -1,0 +1,23 @@
+package uk.gov.justice.hmpps.prison.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmailHelperTest {
+    @Test
+    void formatToLowercase() {
+        assertThat(EmailHelper.format(" JOHN brian")).isEqualTo("john brian");
+    }
+
+    @Test
+    void formatTrim() {
+        assertThat(EmailHelper.format(" john obrian  ")).isEqualTo("john obrian");
+    }
+
+    @Test
+    void formatReplaceMicrosoftQuote() {
+        assertThat(EmailHelper.format(" JOHN O’brian")).isEqualTo("john o'brian");
+    }
+}


### PR DESCRIPTION
This is to enable us to search for users by email if they
have not yet logged into DPS via HMPPS Auth (so we wouldn't
find them there yet) but they do have an email address set
up in NOMIS.