### PR TITLE
P4-2813 adding (optional) non-breaking movement type filter param to movements out for given date endpoint so can filter by type where needed.

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/MovementResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/MovementResource.java
@@ -146,8 +146,12 @@ public class MovementResource {
             @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class)})
     @ApiOperation(value = "", nickname = "getOffendersOut")
     @GetMapping("/{agencyId}/out/{isoDate}")
-    public List<OffenderOutTodayDto> getOffendersOutToday(@PathVariable("agencyId") @ApiParam(value = "The prison id", required = true) final String agencyId, @PathVariable("isoDate") @org.springframework.format.annotation.DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @ApiParam(value = "date", required = true) final LocalDate movementsDate) {
-        return movementsService.getOffendersOut(agencyId, movementsDate);
+    public List<OffenderOutTodayDto> getOffendersOutToday(
+        @PathVariable("agencyId") @ApiParam(value = "The prison id", required = true) final String agencyId,
+        @PathVariable("isoDate") @org.springframework.format.annotation.DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @ApiParam(value = "date", required = true) final LocalDate movementsDate,
+        @RequestParam(value = "movementType", required = false) @ApiParam(value = "The optional movement type to filter by e.g CRT, REL, TAP, TRN") final String movementType
+    ) {
+        return movementsService.getOffendersOut(agencyId, movementsDate, movementType);
     }
 
     @ApiResponses({

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/MovementsRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/MovementsRepository.java
@@ -87,11 +87,12 @@ public class MovementsRepository extends RepositoryBase {
     }
 
 
-    public List<OffenderMovement> getOffendersOut(final String agencyId, final LocalDate movementDate) {
+    public List<OffenderMovement> getOffendersOut(final String agencyId, final LocalDate movementDate, final String movementType) {
         final var sql = MovementsRepositorySql.GET_OFFENDERS_OUT_TODAY.getSql();
         return jdbcTemplate.query(sql, createParams(
                 "agencyId", agencyId,
-                "movementDate", DateTimeConverter.toDate(movementDate)),
+                "movementDate", DateTimeConverter.toDate(movementDate),
+                "movementType", movementType),
                 OFFENDER_MOVEMENT_MAPPER);
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/sql/MovementsRepositorySql.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/sql/MovementsRepositorySql.kt
@@ -292,6 +292,7 @@ enum class MovementsRepositorySql(val sql: String) {
         INNER JOIN OFFENDERS               ON OFFENDERS.OFFENDER_ID = OB.OFFENDER_ID
         LEFT JOIN REFERENCE_CODES RC2 ON RC2.CODE = OEM.MOVEMENT_REASON_CODE AND RC2.DOMAIN = 'MOVE_RSN'
         WHERE
+        OEM.MOVEMENT_TYPE = COALESCE(:movementType, OEM.MOVEMENT_TYPE) AND
         OEM.MOVEMENT_DATE = :movementDate AND
         OEM.DIRECTION_CODE = 'OUT' AND
                 OEM.FROM_AGY_LOC_ID = :agencyId

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/MovementsService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/MovementsService.java
@@ -51,6 +51,8 @@ import java.util.stream.Collectors;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.text.WordUtils.capitalizeFully;
+import static org.apache.commons.lang3.StringUtils.upperCase;
+import static org.apache.commons.lang3.StringUtils.stripToNull;
 
 @Slf4j
 @Service
@@ -117,9 +119,9 @@ public class MovementsService {
     }
 
     @VerifyAgencyAccess
-    public List<OffenderOutTodayDto> getOffendersOut(final String agencyId, final LocalDate movementDate) {
+    public List<OffenderOutTodayDto> getOffendersOut(final String agencyId, final LocalDate movementDate, final String movementType) {
 
-        final var offenders = movementsRepository.getOffendersOut(agencyId, movementDate);
+        final var offenders = movementsRepository.getOffendersOut(agencyId, movementDate, upperCase(stripToNull(movementType)));
 
         return offenders
                 .stream()

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/MovementResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/MovementResourceTest.java
@@ -223,4 +223,47 @@ public class MovementResourceTest extends ResourceTest {
         assertThatStatus(response, HttpStatus.OK.value());
         assertThat(getBodyAsJsonContent(response)).isStrictlyEqualToJson("movements_upcoming_court.json");
     }
+
+    @Test
+    public void testGetAllMovementsOutForAGivenDate() {
+        final var token = authTokenHelper.getToken(AuthTokenHelper.AuthToken.NORMAL_USER);
+
+        final var response = testRestTemplate.exchange(
+            "/api/movements/{agencyId}/out/{isoDate}",
+            HttpMethod.GET,
+            createHttpEntity(token, null),
+            new ParameterizedTypeReference<String>() {
+            }, "LEI", LocalDate.of(2017, 7, 16)
+        );
+
+        assertThatStatus(response, HttpStatus.OK.value());
+        assertThat(getBodyAsJsonContent(response)).isStrictlyEqualToJson("movements_out_on_given_day.json");
+    }
+
+    @Test
+    public void testGetAllMovementsOutForAGivenDateAndMovementType() {
+        final var token = authTokenHelper.getToken(AuthTokenHelper.AuthToken.NORMAL_USER);
+
+        final var movementsFoundResponse = testRestTemplate.exchange(
+            "/api/movements/{agencyId}/out/{isoDate}?movementType={movementType}",
+            HttpMethod.GET,
+            createHttpEntity(token, null),
+            new ParameterizedTypeReference<String>() {
+            }, "LEI", LocalDate.of(2017, 7, 16), "tap"
+        );
+
+        assertThatStatus(movementsFoundResponse, HttpStatus.OK.value());
+        assertThat(getBodyAsJsonContent(movementsFoundResponse)).isStrictlyEqualToJson("movements_out_on_given_day.json");
+
+        final var noMovementsResponse = testRestTemplate.exchange(
+            "/api/movements/{agencyId}/out/{isoDate}?movementType={movementType}",
+            HttpMethod.GET,
+            createHttpEntity(token, null),
+            new ParameterizedTypeReference<String>() {
+            }, "LEI", LocalDate.of(2017, 7, 16), "REL"
+        );
+
+        assertThatStatus(noMovementsResponse, HttpStatus.OK.value());
+        assertThat(noMovementsResponse.getBody()).isEqualTo("[]");
+    }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/MovementsRepositoryTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/MovementsRepositoryTest.java
@@ -174,6 +174,41 @@ public class MovementsRepositoryTest {
     }
 
     @Test
+    public void canRetrieveOffendersOutForAGivenDate() {
+        final var offender = OffenderMovement.builder()
+            .offenderNo("Z0020ZZ")
+            .dateOfBirth(LocalDate.of(1966, 1, 1))
+            .firstName("BURT")
+            .lastName("REYNOLDS")
+            .fromAgency("LEI")
+            .directionCode("OUT")
+            .movementTime(LocalTime.of(0, 0))
+            .movementDate(LocalDate.of(2017, 7, 16))
+            .movementReasonDescription("Funerals And Deaths")
+            .build();
+
+        assertThat(repository.getOffendersOut("LEI", LocalDate.of(2017, Month.JULY, 16), null)).containsExactly(offender);
+    }
+
+    @Test
+    public void canRetrieveOffendersOutForAGivenDateAndMoveType() {
+        final var offender = OffenderMovement.builder()
+            .offenderNo("Z0020ZZ")
+            .dateOfBirth(LocalDate.of(1966, 1, 1))
+            .firstName("BURT")
+            .lastName("REYNOLDS")
+            .fromAgency("LEI")
+            .directionCode("OUT")
+            .movementTime(LocalTime.of(0, 0))
+            .movementDate(LocalDate.of(2017, 7, 16))
+            .movementReasonDescription("Funerals And Deaths")
+            .build();
+
+        assertThat(repository.getOffendersOut("LEI", LocalDate.of(2017, Month.JULY, 16), "TAP")).containsExactly(offender);
+        assertThat(repository.getOffendersOut("LEI", LocalDate.of(2017, Month.JULY, 16), "REL")).isEmpty();
+    }
+
+    @Test
     public void canRetrieveOffendersInReception() {
         final var offenders = repository.getOffendersInReception("MDI");
 

--- a/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/movements_out_on_given_day.json
+++ b/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/movements_out_on_given_day.json
@@ -1,0 +1,10 @@
+[
+  {
+    "offenderNo": "Z0020ZZ",
+    "dateOfBirth": "1966-01-01",
+    "reasonDescription": "Funerals And Deaths",
+    "timeOut": "00:00:00",
+    "firstName": "Burt",
+    "lastName": "Reynolds"
+  }
+]


### PR DESCRIPTION
Changes:

Updating existing endpoint (with non-braking change) to add an optional request query parameter 'movementType' to filter the movements 'out' for a given date.

This enables PECS (Book a Secure Move) to work out the number of releases for a given agency on a specific date.  Other existing endpoints were considered but did not really make sense in terms of easily changing.  Adding a new endpoint seemed like overkill.