### PR TITLE
Fix ministryofjustice/prison-api#915 - Explicitly define the prison-api project's Open Source Contribution policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Crown Copyright (Ministry of Justice)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
[_The LICENSE file_](https://github.com/deduper/prison-api/blob/oss-fork-915/LICENSE) in this commit was copied directly from [_the MOJ's prison-offender-events project_](https://github.com/ministryofjustice/prison-offender-events/blob/main/LICENSE). 

Since other MOJ projects have OSS licenses, I've submitted this pull request assuming ([_like the GitHub documentation suggests_](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository)) the absence of a license in prison-api is simply an oversight.