### PR TITLE
P4-2976 trialing a change to see if it resolves an issue in production

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -200,7 +201,7 @@ public class OffenderBooking extends ExtendedAuditableEntity {
     }
 
     public Optional<OffenderCourtCase> getCourtCaseBy(final Long courtCaseId) {
-        return courtCases == null ? Optional.empty() : courtCases.stream().filter(cc -> cc.getId().equals(courtCaseId)).findFirst();
+        return courtCases == null ? Optional.empty() : courtCases.stream().filter(Objects::nonNull).filter(cc -> cc.getId().equals(courtCaseId)).findFirst();
     }
 
     public boolean isActive() {

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
@@ -17,10 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OffenderBookingTest {
     private static final OffenderCourtCase ACTIVE_COURT_CASE = OffenderCourtCase.builder()
+        .id(1L)
         .caseStatus(new CaseStatus("A", "Active"))
         .build();
 
     private static final OffenderCourtCase INACTIVE_COURT_CASE = OffenderCourtCase.builder()
+        .id(2L)
         .caseStatus(new CaseStatus("I", "Inactive"))
         .build();
 
@@ -49,6 +51,17 @@ public class OffenderBookingTest {
 
     @Nested
     class CourtCases {
+
+        @Test
+        void getCourtCaseBy_empty_when_no_matching_case_id() {
+            assertThat(OffenderBooking.builder().build().getCourtCaseBy(1L)).isEmpty();
+        }
+
+        @Test
+        void getCourtCaseBy_returns_matching_case() {
+            assertThat(OffenderBooking.builder().courtCases(List.of(ACTIVE_COURT_CASE)).build().getCourtCaseBy(ACTIVE_COURT_CASE.getId())).hasValue(ACTIVE_COURT_CASE);
+        }
+
         @Test
         void getCourtCases_returns_all_court_cases() {
             final var booking = OffenderBooking.builder().courtCases(List.of(ACTIVE_COURT_CASE, INACTIVE_COURT_CASE)).build();
@@ -72,14 +85,15 @@ public class OffenderBookingTest {
 
         @Test
         void handleNullCourtCasesEntries() {
-            final var courtCases = new ArrayList<>();
+            final var courtCases = new ArrayList<OffenderCourtCase>();
             courtCases.add(ACTIVE_COURT_CASE);
             courtCases.add(INACTIVE_COURT_CASE);
             courtCases.add(null);
 
-            final var booking = OffenderBooking.builder().courtCases((List) courtCases).build();
+            final var booking = OffenderBooking.builder().courtCases(courtCases).build();
 
             assertThat(booking.getActiveCourtCases()).containsExactly(ACTIVE_COURT_CASE);
+            assertThat(booking.getCourtCaseBy(9999L)).isEmpty();
         }
     }
 


### PR DESCRIPTION
**Changes:**

BaSM is seeing a `NullPointer` exception when trying to schedule court hearings for bookings with a court case id.

`"java.lang.NullPointerException: Cannot invoke \"uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderCourtCase.getId()\" because \"cc\" is null\n\tat uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderBooking.lambda..."`

I have not actually been able to recreate this locally but would like to try this to see if it resolves it.