### PR TITLE
DT-2327: ♻️ Remove unused endpoints

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/UserResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/UserResource.java
@@ -25,7 +25,6 @@ import uk.gov.justice.hmpps.prison.api.model.CaseloadUpdate;
 import uk.gov.justice.hmpps.prison.api.model.ErrorResponse;
 import uk.gov.justice.hmpps.prison.api.model.Location;
 import uk.gov.justice.hmpps.prison.api.model.ReferenceCode;
-import uk.gov.justice.hmpps.prison.api.model.StaffDetail;
 import uk.gov.justice.hmpps.prison.api.model.UserDetail;
 import uk.gov.justice.hmpps.prison.api.model.UserRole;
 import uk.gov.justice.hmpps.prison.api.support.Order;
@@ -71,34 +70,6 @@ public class UserResource {
     }
 
     @ApiResponses({
-            @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"),
-            @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
-    @ApiOperation(value = "List of users who have the named role at the named caseload", notes = "List of users who have the named role at the named caseload", nickname = "getAllUsersHavingRoleAtCaseload")
-    @GetMapping("/access-roles/caseload/{caseload}/access-role/{roleCode}")
-    public Set<String> getAllUsersHavingRoleAtCaseload(@PathVariable("caseload") @ApiParam(value = "Caseload Id", required = true) final String caseload, @PathVariable("roleCode") @ApiParam(value = "access role code", required = true) final String roleCode) {
-        return userService.getAllUsernamesForCaseloadAndRole(caseload, roleCode);
-    }
-
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "OK", response = UserDetail.class, responseContainer = "List"),
-            @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
-    @ApiOperation(value = "Get user details by prison.", notes = "Get user details by prison.", nickname = "getUsersByCaseLoad")
-    @GetMapping("/caseload/{caseload}")
-    public ResponseEntity<List<UserDetail>> getUsersByCaseLoad(@PathVariable("caseload") @ApiParam(value = "The agency (prison) id.", required = true) final String caseload, @RequestParam(value = "nameFilter", required = false) @ApiParam("Filter results by first name and/or username and/or last name of staff member.") final String nameFilter, @RequestParam(value = "accessRole", required = false) @ApiParam("Filter results by access role") final String accessRole, @RequestHeader(value = "Page-Offset", defaultValue = "0", required = false) @ApiParam(value = "Requested offset of first record in returned collection of caseload records.", defaultValue = "0") final Long pageOffset, @RequestHeader(value = "Page-Limit", defaultValue = "10", required = false) @ApiParam(value = "Requested limit to number of caseload records returned.", defaultValue = "10") final Long pageLimit, @RequestHeader(value = "Sort-Fields", required = false) @ApiParam("Comma separated list of one or more of the following fields - <b>firstName, lastName</b>") final String sortFields, @RequestHeader(value = "Sort-Order", defaultValue = "ASC", required = false) @ApiParam(value = "Sort order (ASC or DESC) - defaults to ASC.", defaultValue = "ASC") final Order sortOrder) {
-
-        final var pageRequest = new PageRequest(sortFields, sortOrder, pageOffset, pageLimit);
-        final var userDetails = userService.getUsersByCaseload(caseload, nameFilter, accessRole, pageRequest);
-
-        return ResponseEntity.ok()
-                .headers(userDetails.getPaginationHeaders())
-                .body(userDetails.getItems());
-    }
-
-    @ApiResponses({
             @ApiResponse(code = 200, message = "OK", response = UserDetail.class, responseContainer = "List"),
             @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
             @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
@@ -120,18 +91,6 @@ public class UserResource {
         return ResponseEntity.ok()
                 .headers(userDetails.getPaginationHeaders())
                 .body(userDetails.getItems());
-    }
-
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "OK", response = UserDetail.class, responseContainer = "List"),
-            @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
-    @Deprecated
-    @ApiOperation(value = "Deprecated: Get staff details for local administrators", notes = "Deprecated: please use /users/local-administrator/available", nickname = "getStaffUsersForLocalAdministrator")
-    @GetMapping("/local-administrator/caseload/{caseload}")
-    public ResponseEntity<List<UserDetail>> deprecatedPleaseRemove(@PathVariable("caseload") @ApiParam(value = "The agency (prison) id.", required = true, allowEmptyValue = true) final String caseload, @RequestParam(value = "nameFilter", required = false) @ApiParam("Filter results by first name and/or username and/or last name of staff member.") final String nameFilter, @RequestParam(value = "accessRole", required = false) @ApiParam("Filter results by access role") final String accessRole, @RequestHeader(value = "Page-Offset", defaultValue = "0", required = false) @ApiParam(value = "Requested offset of first record in returned collection of caseload records.", defaultValue = "0") final Long pageOffset, @RequestHeader(value = "Page-Limit", defaultValue = "10", required = false) @ApiParam(value = "Requested limit to number of caseload records returned.", defaultValue = "10") final Long pageLimit, @RequestHeader(value = "Sort-Fields", required = false) @ApiParam("Comma separated list of one or more of the following fields - <b>firstName, lastName</b>") final String sortFields, @RequestHeader(value = "Sort-Order", defaultValue = "ASC", required = false) @ApiParam(value = "Sort order (ASC or DESC) - defaults to ASC.", defaultValue = "ASC") final Order sortOrder) {
-        return getStaffUsersForLocalAdministrator(nameFilter, accessRole, Status.ALL, pageOffset, pageLimit, sortFields, sortOrder);
     }
 
     @ApiResponses({
@@ -290,18 +249,6 @@ public class UserResource {
                             .build());
         }
         return ResponseEntity.ok().build();
-    }
-
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "OK", response = StaffDetail.class),
-            @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class),
-            @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class),
-            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class)})
-    @ApiOperation(value = "Staff detail.", notes = "Deprecated: Use <b>/staff/{staffId}</b> instead. This API will be removed in a future release.", nickname = "getStaffDetail")
-    @Deprecated
-    @GetMapping("/staff/{staffId}")
-    public StaffDetail getStaffDetail(@PathVariable("staffId") @ApiParam(value = "The staff id of the staff member.", required = true) final Long staffId) {
-        return staffService.getStaffDetail(staffId);
     }
 
     @ApiResponses({

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/UserService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/UserService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.hmpps.prison.api.model.AccessRole;
 import uk.gov.justice.hmpps.prison.api.model.CaseLoad;
 import uk.gov.justice.hmpps.prison.api.model.CaseloadUpdate;
-import uk.gov.justice.hmpps.prison.api.model.StaffUserRole;
 import uk.gov.justice.hmpps.prison.api.model.UserDetail;
 import uk.gov.justice.hmpps.prison.api.model.UserRole;
 import uk.gov.justice.hmpps.prison.api.support.Page;
@@ -140,14 +139,6 @@ public class UserService {
                 .withMessage("User not found for external identifier with idType [{}] and id [{}].", idType, id));
     }
 
-    public Set<String> getAllUsernamesForCaseloadAndRole(final String caseload, final String roleCode) {
-        return userRepository
-                .getAllStaffRolesForCaseload(caseload, roleCode)
-                .stream()
-                .map(StaffUserRole::getUsername)
-                .collect(Collectors.toSet());
-    }
-
     public boolean isUserAssessibleCaseloadAvailable(final String caseload, final String username) {
         return userRepository.isUserAssessibleCaseloadAvailable(caseload, username);
     }
@@ -254,15 +245,6 @@ public class UserService {
                 .caseload(caseloadId)
                 .numUsersEnabled(caseloadsAdded.size())
                 .build();
-    }
-
-    @PreAuthorize("hasRole('MAINTAIN_ACCESS_ROLES_ADMIN')")
-    public Page<UserDetail> getUsersByCaseload(final String caseload, final String nameFilter, final String accessRole, final PageRequest pageRequest) {
-
-        final var pageWithDefaults = getPageRequestDefaultLastNameOrder(pageRequest);
-
-        return userRepository
-                .findUsersByCaseload(caseload, accessRole, new NameFilter(nameFilter), pageWithDefaults);
     }
 
     public Page<UserDetail> getUsersAsLocalAdministrator(final String laaUsername, final String nameFilter, final String accessRole, final Status status, final PageRequest pageRequest) {

--- a/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/UserStepDefinitions.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/UserStepDefinitions.java
@@ -145,11 +145,6 @@ public class UserStepDefinitions extends AbstractStepDefinitions {
         user.verifyCaseNoteTypesHaveSubTypes();
     }
 
-    @When("^a request for users having role \"([^\"]*)\" at caseload \"([^\"]*)\" is made$")
-    public void aRequestForUsersHavingAtIsMade(final String role, final String caseload) {
-        user.findUsernamesHavingRoleAtCaseload(role, caseload);
-    }
-
     @Then("^the matching \"([^\"]*)\" are returned$")
     public void theMatchingAreReturned(final String usernames) {
         user.verifyUsernames(usernames);
@@ -185,14 +180,9 @@ public class UserStepDefinitions extends AbstractStepDefinitions {
         user.userDoesNotHaveRoleAtCaseload(username, role, caseload);
     }
 
-    @When("^a request for users with caseload \"([^\"]*)\" is made$")
-    public void aRequestForUsersWithCaseloadIsMade(final String caseloadId) {
-        user.getUsersByCaseload(caseloadId, null, null, false);
-    }
-
     @When("^a request for users is made$")
     public void aRequestForUsersIsMade() {
-        user.getUsers(null, null, false);
+        user.getUsers(null, null);
     }
 
     @When("^a request for users with usernames \"([^\"]*)\" is made$")
@@ -213,11 +203,6 @@ public class UserStepDefinitions extends AbstractStepDefinitions {
     @Then("^a list of roles is returned with role codes \"([^\"]*)\"$")
     public void aListOfRolesIsReturnedWithRoleCodes(final String roleCodeList) {
         user.verifyRoleList(roleCodeList);
-    }
-
-    @When("^a request for users with caseload \"([^\"]*)\" and namefilter \"([^\"]*)\" and role \"([^\"]*)\" is made$")
-    public void aRequestForUsersWithCaseloadAndNamefilterAndRoleIsMade(final String caseloadId, final String nameFilter, final String roleCode) {
-        user.getUsersByCaseload(caseloadId, roleCode, nameFilter, false);
     }
 
     @When("^a request for users by local administrator with namefilter \"([^\"]*)\" and role \"([^\"]*)\" is made$")

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/UserServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/UserServiceImplTest.java
@@ -68,15 +68,6 @@ public class UserServiceImplTest {
     }
 
     @Test
-    public void testGetUsersByCaseload() {
-        final var pr = new PageRequest("lastName,firstName", Order.ASC, 0L, 10L);  //the default if non provided
-        final var nameFilterDto = new NameFilter("A");
-        userService.getUsersByCaseload(LEEDS_CASELOAD_ID, "A", ROLE_CODE, null);
-
-        verify(userRepository).findUsersByCaseload(eq(LEEDS_CASELOAD_ID), eq(ROLE_CODE), refEq(nameFilterDto), refEq(pr));
-    }
-
-    @Test
     public void testGetUsers() {
         final var pr = new PageRequest("lastName,firstName", Order.ASC, 0L, 10L);  //the default if non provided
         final var nameFilterDto = new NameFilter("A");
@@ -110,15 +101,6 @@ public class UserServiceImplTest {
         userService.getUsers("A", ROLE_CODE, Status.INACTIVE, null);
 
         verify(userRepository).findUsers(eq(ROLE_CODE), refEq(nameFilterDto), eq(Status.INACTIVE),refEq(pr));
-    }
-
-    @Test
-    public void testGetUsersByCaseloadWithSortFieldDifferentToDefault() {
-        final var pr = new PageRequest("firstName", Order.ASC, 10L, 20L);
-        final var nameFilterDto = new NameFilter("A");
-        userService.getUsersByCaseload(LEEDS_CASELOAD_ID, "A", ROLE_CODE, pr);
-
-        verify(userRepository).findUsersByCaseload(eq(LEEDS_CASELOAD_ID), eq(ROLE_CODE), refEq(nameFilterDto), refEq(pr));
     }
 
     @Test

--- a/src/test/resources/features/users.feature
+++ b/src/test/resources/features/users.feature
@@ -27,19 +27,6 @@ Feature: User Details and Roles
       | API_TEST_USER       | KW_ADMIN,OMIC_ADMIN  |
       | NO_CASELOAD_USER    | VIEW_PRISONER_DATA,LICENCE_RO |
 
-  Scenario Outline: As a logged in user I can find out which users have a given role at a particular caseload
-    Given a user has authenticated with the API
-    When a request for users having role "<role>" at caseload "<caseload>" is made
-    Then the matching "<usernames>" are returned
-
-    Examples:
-    | role     | caseload | usernames                          |
-    | WING_OFF | LEI      | PRISON_API_USER,ITAG_USER,JBRIEN,NONWEB,RENEGADE |
-    | WING_OFF | MUL      | API_TEST_USER                      |
-    | WING_OFF | XXXXXX   |                                    |
-    | XXXXX    | LEI      |                                    |
-    | KW_ADMIN | NWEB     | API_TEST_USER,ITAG_USER            |
-
   Scenario: A trusted client can make api-role assignments to users.
     Given a trusted client that can maintain access roles has authenticated with the API
     When the client assigns api-role "KW_ADMIN" to user "API_TEST_USER"
@@ -86,16 +73,6 @@ Feature: User Details and Roles
     Given a user has a token name of "ADMIN_TOKEN"
     When a request for users with usernames "JBRIEN,RENEGADE" is made
     Then a list of users is returned with usernames "JBRIEN,RENEGADE"
-
-  Scenario: A list of staff users by caseload and namefilter can be retrieved
-    Given a user has a token name of "ADMIN_TOKEN"
-    When a request for users with caseload "LEI" and namefilter "User" and role "" is made
-    Then a list of users is returned with usernames "PRISON_API_USER,ITAG_USER,CA_USER,DM_USER,PPL_USER,RCTL_USER,POM_USER,PF_RO_USER"
-
-  Scenario: A list of staff users by caseload and namefilter and access role can be retrieved
-    Given a user has a token name of "ADMIN_TOKEN"
-    When a request for users with caseload "LEI" and namefilter "User" and role "OMIC_ADMIN" is made
-    Then a list of users is returned with usernames "ITAG_USER"
 
   Scenario: A list of staff users by LAA and namefilter can be retrieved
     Given a user has a token name of "LAA_USER"


### PR DESCRIPTION
Found endpoints that were being used by running
```
requests
| where cloud_RoleName == 'prison-api'
| where name startswith "GET /api/users"
| distinct name
```
and got results
```
  | GET /api/users/ |  
  | GET /api/users/{username} |  
  | GET /api/users/{username}/access-roles/caseload/{caseload} |  
  | GET /api/users/local-administrator/available |  
  | GET /api/users/me |  
  | GET /api/users/me/caseLoads |  
  | GET /api/users/me/caseNoteTypes |  
  | GET /api/users/me/locations |  
  | GET /api/users/me/roles
```
This PR then removes
``` 
    @GetMapping("/access-roles/caseload/{caseload}/access-role/{roleCode}")
    @GetMapping("/caseload/{caseload}")
    @GetMapping("/local-administrator/caseload/{caseload}")
    @GetMapping("/staff/{staffId}")
```