### PR TITLE
DCS-1134 Respecting the location parameter during prioritised search

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/GlobalSearchService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/GlobalSearchService.java
@@ -146,6 +146,7 @@ public class GlobalSearchService {
                 .dob(originalCriteria.getDob())
                 .partialNameMatch(originalCriteria.isPartialNameMatch())
                 .anyMatch(originalCriteria.isAnyMatch())
+                .location(originalCriteria.getLocation())
                 .build();
 
         var response = executeQuery(criteria, pageRequest);

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/GlobalSearchServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/GlobalSearchServiceImplTest.java
@@ -195,10 +195,11 @@ public class GlobalSearchServiceImplTest {
                 .prioritisedMatch(true)
                 .offenderNos(TEST_OFFENDER_NO)
                 .lastName(TEST_LAST_NAME)
+                .location("IN")
                 .build();
 
         final var offNoCriteria = PrisonerDetailSearchCriteria.builder().offenderNos(TEST_OFFENDER_NO).build();
-        final var personalAttrsCriteria = PrisonerDetailSearchCriteria.builder().lastName(TEST_LAST_NAME).build();
+        final var personalAttrsCriteria = PrisonerDetailSearchCriteria.builder().lastName(TEST_LAST_NAME).location("IN").build();
 
         when(inmateRepository.generateFindOffendersQuery(offNoCriteria)).thenReturn(TEST_OFFENDER_NO_QUERY);
         when(inmateRepository.generateFindOffendersQuery(personalAttrsCriteria)).thenReturn(TEST_PERSONAL_ATTRS_QUERY);


### PR DESCRIPTION
Currently if a prioritised search falls through to personalised details if no results found for offender number or PNC.
In this scenario, the location parameter is ignored - this adds it back in 