### PR TITLE
DT-2332 Log query parameter prior to removal

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/LocationService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/LocationService.java
@@ -20,6 +20,8 @@ import uk.gov.justice.hmpps.prison.service.support.LocationProcessor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Service
@@ -72,6 +74,7 @@ public class LocationService {
     }
 
     public Page<OffenderBooking> getInmatesFromLocation(final long locationId, final String username, final String query, final String orderByField, final Order order, final long offset, final long limit) {
+        Optional.ofNullable(query).filter(Predicate.not(String::isBlank)).ifPresent(q -> log.warn("Unsafe query parameter {} has been received", q));
         // validation check?
         locationRepository.findLocation(locationId, username);
 


### PR DESCRIPTION
Pretty certain this is always blank, so logging to double check prior to its removal