### PR TITLE
CVSL-241: Add a POST endpoint to get HDC status for a list of booking IDs

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/HomeDetentionCurfew.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/HomeDetentionCurfew.java
@@ -38,4 +38,7 @@ public class HomeDetentionCurfew {
 
     @ApiModelProperty(required = true, value = "Approval status date. ISO-8601 format. YYYY-MM-DD", example = "2018-12-31")
     LocalDate approvalStatusDate;
+
+    @ApiModelProperty(value = "Offender booking ID", example = "123")
+    private Long bookingId;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderSentenceResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderSentenceResource.java
@@ -90,6 +90,17 @@ public class OffenderSentenceResource {
     }
 
     @ApiResponses({
+        @ApiResponse(code = 200, message = "List of HDC status information", response = HomeDetentionCurfew.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class),
+    })
+    @ApiOperation("Retrieve the latest Home Detention Curfew status for a list of offender booking identifiers")
+    @PostMapping("/home-detention-curfews/latest")
+    public List<HomeDetentionCurfew> getBatchLatestHomeDetentionCurfew(@RequestBody @ApiParam(value = "A list of booking ids", required = true) final List<Long> bookingIds) {
+        validateBookingIdList(bookingIds);
+        return offenderCurfewService.getBatchLatestHomeDetentionCurfew(bookingIds);
+    }
+
+    @ApiResponses({
             @ApiResponse(code = 204, message = "The checks passed flag was set"),
             @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
             @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
@@ -184,6 +195,12 @@ public class OffenderSentenceResource {
     private void validateOffenderList(final List<?> offenderList) {
         if (CollectionUtils.isEmpty(offenderList)) {
             throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "List of Offender Ids must be provided");
+        }
+    }
+
+    private void validateBookingIdList(final List<Long> bookingIdList) {
+        if (CollectionUtils.isEmpty(bookingIdList)) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "List of Booking Ids must be provided");
         }
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/OffenderCurfewRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/OffenderCurfewRepository.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -181,6 +182,18 @@ public class OffenderCurfewRepository extends RepositoryBase {
                         "statusTrackingCodes", statusTrackingCodesToMatch),
                 HOME_DETENTION_CURFEW_ROW_MAPPER);
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
+
+    public List<HomeDetentionCurfew> getBatchLatestHomeDetentionCurfew(List<Long> bookingIds, Set<String> statusTrackingCodesToMatch) {
+        val results = jdbcTemplate.query(
+                OffenderCurfewRepositorySql.LATEST_BATCH_HOME_DETENTION_CURFEW.getSql(),
+                createParams(
+                  "bookingIds", bookingIds,
+                  "statusTrackingCodes", statusTrackingCodesToMatch),
+                  HOME_DETENTION_CURFEW_ROW_MAPPER
+                );
+        return results;
     }
 
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/curfews/OffenderCurfewService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/curfews/OffenderCurfewService.java
@@ -130,6 +130,11 @@ public class OffenderCurfewService {
                 .orElseThrow(() -> new EntityNotFoundException("No 'latest' Home Detention Curfew found for bookingId " + bookingId));
     }
 
+    @PreAuthorize("hasRole('SYSTEM_USER')")
+    public List<HomeDetentionCurfew> getBatchLatestHomeDetentionCurfew(final List<Long> bookingIds) {
+        return offenderCurfewRepository.getBatchLatestHomeDetentionCurfew(bookingIds, StatusTrackingCodes.REFUSED_REASON_CODES);
+    }
+
     @Transactional
     @HasWriteScope
     @PreAuthorize("hasRole('SYSTEM_USER')")

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderSentenceResourceImplIntTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderSentenceResourceImplIntTest.java
@@ -6,11 +6,10 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.justice.hmpps.prison.api.model.ErrorResponse;
-import uk.gov.justice.hmpps.prison.api.model.OffenderSentenceAndOffences;
-import uk.gov.justice.hmpps.prison.api.model.v1.Offender;
 
 import java.util.List;
 import java.util.Map;
+import uk.gov.justice.hmpps.prison.api.model.HomeDetentionCurfew;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -268,5 +267,29 @@ public class OffenderSentenceResourceImplIntTest extends ResourceTest {
             });
 
         assertThatJsonFileAndStatus(response, HttpStatus.OK.value(), "sentences-and-offences-details.json");
+    }
+
+    @Test
+    public void postHdcLatestStatus_success_multiple() {
+        final var requestEntity = createHttpEntityWithBearerAuthorisationAndBody(
+            "RO_USER",
+            List.of("ROLE_SYSTEM_USER"),
+            List.of(-1L, -2L, -3L)
+        );
+
+        var responseType = new ParameterizedTypeReference<List<HomeDetentionCurfew>>() {};
+
+        final var responseEntity = testRestTemplate
+            .exchange(
+                "/api/offender-sentences/home-detention-curfews/latest",
+                HttpMethod.POST,
+                requestEntity,
+                responseType
+            );
+
+        assertThatStatus(responseEntity, 200);
+        assertThat(responseEntity.getBody()).isNotEmpty();
+        assertThat(responseEntity.getBody()).hasSize(3);
+        assertThat(responseEntity.getBody()).extracting("bookingId").containsOnly(-1L, -2L, -3L);
     }
 }


### PR DESCRIPTION
The HDC status is only currently available for a single booking Id in a GET endpoint.
For Create and Vary a Licence, it is useful to retrieve this information for several booking Ids (the cases which are allocated to one probation officer, generally 10-25).  This PR add a POST endpoint, service method and repository + SQL and tests for this purpose.