### PR TITLE
SDI-76 New endpoint to retrieve list of domains

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/ReferenceDomainResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/ReferenceDomainResource.java
@@ -25,6 +25,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.justice.hmpps.prison.api.model.ErrorResponse;
 import uk.gov.justice.hmpps.prison.api.model.ReferenceCode;
 import uk.gov.justice.hmpps.prison.api.model.ReferenceCodeInfo;
+import uk.gov.justice.hmpps.prison.api.model.ReferenceDomain;
 import uk.gov.justice.hmpps.prison.api.support.Order;
 import uk.gov.justice.hmpps.prison.core.ProxyUser;
 import uk.gov.justice.hmpps.prison.service.CaseNoteService;
@@ -117,6 +118,16 @@ public class ReferenceDomainResource {
                         nvl(pageLimit, 10L));
 
         return ResponseEntity.ok().headers(referenceCodes.getPaginationHeaders()).body(referenceCodes.getItems());
+    }
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
+    @Operation(summary = "List of all reference domains", description = "A reference domain can be used to retrieve all codes related to that domian")
+    @GetMapping("/domains")
+    public List<ReferenceDomain> getAllReferenceDomains() {
+        return referenceDomainService.getAllDomains();
     }
 
     @ApiResponses({

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/ReferenceDomain.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/ReferenceDomain.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.hmpps.prison.repository.jpa.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Entity
+@Table(name = "reference_domains")
+public class ReferenceDomain {
+    @Id
+    @Column
+    private String domain;
+    @Column
+    private String description;
+    @Column
+    private String domainStatus;
+    @Column
+    private String ownerCode;
+    @Column
+    private String applnCode;
+    @Column
+    private String parentDomain;
+}

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/ReferenceDomainRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/ReferenceDomainRepository.java
@@ -1,0 +1,8 @@
+package uk.gov.justice.hmpps.prison.repository.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReferenceDomainRepository extends JpaRepository<uk.gov.justice.hmpps.prison.repository.jpa.model.ReferenceDomain, String> {
+}

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/ReferenceDomainService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/ReferenceDomainService.java
@@ -8,6 +8,7 @@ import uk.gov.justice.hmpps.prison.api.model.ReferenceCodeInfo;
 import uk.gov.justice.hmpps.prison.api.support.Order;
 import uk.gov.justice.hmpps.prison.api.support.Page;
 import uk.gov.justice.hmpps.prison.repository.ReferenceDataRepository;
+import uk.gov.justice.hmpps.prison.repository.jpa.repository.ReferenceDomainRepository;
 import uk.gov.justice.hmpps.prison.service.support.ReferenceDomain;
 import uk.gov.justice.hmpps.prison.service.support.StringWithAbbreviationsProcessor;
 
@@ -22,9 +23,11 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ReferenceDomainService {
     private final ReferenceDataRepository referenceDataRepository;
+    private final ReferenceDomainRepository referenceDomainRepository;
 
-    public ReferenceDomainService(final ReferenceDataRepository referenceDataRepository) {
+    public ReferenceDomainService(final ReferenceDataRepository referenceDataRepository, ReferenceDomainRepository referenceDomainRepository) {
         this.referenceDataRepository = referenceDataRepository;
+        this.referenceDomainRepository = referenceDomainRepository;
     }
 
     private static String getDefaultOrderBy(final String orderBy) {
@@ -161,5 +164,22 @@ public class ReferenceDomainService {
         verifyReferenceDomain(domain);
 
         return referenceDataRepository.getReferenceCodeByDomainAndDescription(domain, description, wildcard);
+    }
+
+    public List<uk.gov.justice.hmpps.prison.api.model.ReferenceDomain> getAllDomains() {
+        return referenceDomainRepository
+            .findAll()
+            .stream()
+            .map(it -> uk.gov.justice.hmpps.prison.api.model.ReferenceDomain
+                .builder()
+                .domain(it.getDomain())
+                .description(it.getDescription())
+                .domainStatus(it.getDomainStatus())
+                .ownerCode(it.getOwnerCode())
+                .applnCode(it.getApplnCode())
+                .parentDomain(it.getParentDomain())
+                .build()
+            )
+            .toList();
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/ReferenceDataResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/ReferenceDataResourceTest.java
@@ -1,9 +1,13 @@
 package uk.gov.justice.hmpps.prison.api.resource.impl;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper;
 import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken;
@@ -181,4 +185,74 @@ public class ReferenceDataResourceTest extends ResourceTest {
         assertThatJsonFileAndStatus(response, 200, "multiple_ref_data_reverse_lookup.json");
     }
 
+    @Nested
+    @DisplayName("GET /domains")
+    class GetDomainsTest {
+        @Test
+        @DisplayName("must have a valid token to access endpoint")
+        void mustHaveAValidTokenToAccessEndpoint() {
+            assertThat(getDomains(null).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("can have any role to access endpoint")
+        void canHaveAnyRoleToAccessEndpoint() {
+            final var token = authTokenHelper.someClientUser("ROLE_BANANAS");
+
+            assertThat(getDomains(token).getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        @DisplayName("will return a list of domains")
+        void willReturnAListOfDomains() {
+            final var token = authTokenHelper.getToken(AuthTokenHelper.AuthToken.NORMAL_USER);
+
+            final var response = getBodyAsJsonContent(getDomains(token));
+
+            assertThat(response).hasJsonPathArrayValue("$");
+            assertThat(response).extractingJsonPathNumberValue("$.length()").isEqualTo(430);
+        }
+
+        @Test
+        @DisplayName("will return details of a domain")
+        void willReturnDetailsOfADomain() {
+            final var token = authTokenHelper.getToken(AuthTokenHelper.AuthToken.NORMAL_USER);
+
+            final var response = getBodyAsJsonContent(getDomains(token));
+
+            final var domainAt = "$[?(@.domain == '%s')]";
+            final var domainPropertyAt = "$[?(@.domain == '%s')].%s";
+
+            assertThat(response)
+                .hasJsonPathValue(domainAt, "ETHNICITY");
+            assertThat(response)
+                .hasJsonPathValue(domainAt, "SKL_SUB_TYPE");
+
+            assertThat(response)
+                .extractingJsonPathValue(domainPropertyAt, "ETHNICITY", "description").asList().element(0)
+                .isEqualTo("Ethnicity");
+            assertThat(response)
+                .extractingJsonPathValue(domainPropertyAt, "ETHNICITY", "domainStatus").asList().element(0)
+                .isEqualTo("ACTIVE");
+            assertThat(response)
+                .extractingJsonPathValue(domainPropertyAt, "ETHNICITY", "ownerCode").asList().element(0)
+                .isEqualTo("ADMIN");
+            assertThat(response)
+                .extractingJsonPathValue(domainPropertyAt, "ETHNICITY", "applnCode").asList().element(0)
+                .isEqualTo("OMS");
+            assertThat(response)
+                .extractingJsonPathValue(domainPropertyAt, "SKL_SUB_TYPE", "parentDomain").asList().element(0)
+                .isEqualTo("STAFF_SKILLS");
+        }
+
+
+        private ResponseEntity<String> getDomains(String token) {
+            return testRestTemplate.exchange(
+                "/api/reference-domains/domains",
+                HttpMethod.GET,
+                createHttpEntity(token, null),
+                new ParameterizedTypeReference<>() {
+                });
+        }
+    }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/steps/AuthTokenHelper.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/steps/AuthTokenHelper.java
@@ -17,7 +17,7 @@ public class AuthTokenHelper {
 
     private final Map<String, String> tokens = new HashMap<>();
     private String currentToken;
-    private JwtAuthenticationHelper jwtAuthenticationHelper;
+    private final JwtAuthenticationHelper jwtAuthenticationHelper;
 
     public enum AuthToken {
         PRISON_API_USER,
@@ -380,6 +380,16 @@ public class AuthTokenHelper {
                 .username("ITAG_USER") // use ITAG_USER to avoid the pain of creating a new username in the test DB
                 .scope(List.of("read", "write"))
                 .roles(List.of("ROLE_RELEASE_DATES_CALCULATOR"))
+                .expiryTime(Duration.ofDays(365 * 10))
+                .build()
+        );
+    }
+    public String someClientUser(String... roles) {
+        return jwtAuthenticationHelper.createJwt(
+            JwtParameters.builder()
+                .username("Another System")
+                .scope(List.of("read", "write"))
+                .roles(List.of(roles))
                 .expiryTime(Duration.ofDays(365 * 10))
                 .build()
         );

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/ReferenceDomainServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/ReferenceDomainServiceImplTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.hmpps.prison.api.model.ReferenceCode;
 import uk.gov.justice.hmpps.prison.repository.ReferenceDataRepository;
+import uk.gov.justice.hmpps.prison.repository.jpa.repository.ReferenceDomainRepository;
 import uk.gov.justice.hmpps.prison.service.support.ReferenceDomain;
 
 import java.util.Arrays;
@@ -23,12 +24,15 @@ public class ReferenceDomainServiceImplTest {
     @Mock
     private ReferenceDataRepository repository;
 
+    @Mock
+    private ReferenceDomainRepository referenceDomainRepository;
+
     private ReferenceDomainService service;
 
     @BeforeEach
     public void setUp() {
         initMocks(repository);
-        service = new ReferenceDomainService(repository);
+        service = new ReferenceDomainService(repository, referenceDomainRepository);
     }
 
     @Test


### PR DESCRIPTION
Endpoint is likely to only be used by developers who want to guess at the domain they need for other APIs

- Use JPA Repository for domain rather then SQL version since this is standard going forward
- Use JsonPath for testing rather than json file assert that is confusing