### PR TITLE
SDI-78 Create un-paged version of codes for a domain

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/ReferenceCode.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/ReferenceCode.java
@@ -40,7 +40,7 @@ public class ReferenceCode extends ReferenceCodeInfo {
     @Size(max = 12)
     private String code;
 
-    @Schema(description = "List of subordinate reference data items associated with this reference data item.")
+    @Schema(description = "List of subordinate reference data items associated with this reference data item. Not returned by default")
     @Builder.Default
     private List<ReferenceCode> subCodes = new ArrayList<>();
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/ReferenceDomainResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/ReferenceDomainResource.java
@@ -105,9 +105,9 @@ public class ReferenceDomainResource {
             @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
-    @Operation(summary = "List of reference codes for reference domain.", description = "List of reference codes for reference domain.")
+    @Operation(summary = "List of reference codes for reference domain paged.", description = "List of reference codes for reference domain paged. Please note this API has the incorrect name so the non-paged /domains/{domain}/codes version is preferred.")
     @GetMapping("/domains/{domain}")
-    public ResponseEntity<List<ReferenceCode>> getReferenceCodesByDomain(@PathVariable("domain") @Parameter(description = "The domain identifier/name.", required = true) final String domain, @RequestParam(value = "withSubCodes", required = false, defaultValue = "false") @Parameter(description = "Specify whether or not to return reference codes with their associated sub-codes.") final boolean withSubCodes, @RequestHeader(value = "Page-Offset", defaultValue = "0", required = false) @Parameter(description = "Requested offset of first record in returned collection of domain records.") final Long pageOffset, @RequestHeader(value = "Page-Limit", defaultValue = "10", required = false) @Parameter(description = "Requested limit to number of domain records returned.") final Long pageLimit, @RequestHeader(value = "Sort-Fields", required = false) @Parameter(description = "Comma separated list of one or more of the following fields - <b>code, description</b>") final String sortFields, @RequestHeader(value = "Sort-Order", defaultValue = "ASC", required = false) @Parameter(description = "Sort order (ASC or DESC) - defaults to ASC.") final Order sortOrder) {
+    public ResponseEntity<List<ReferenceCode>> getReferenceCodesByDomainPaged(@PathVariable("domain") @Parameter(description = "The domain identifier/name.", required = true) final String domain, @RequestParam(value = "withSubCodes", required = false, defaultValue = "false") @Parameter(description = "Specify whether or not to return reference codes with their associated sub-codes.") final boolean withSubCodes, @RequestHeader(value = "Page-Offset", defaultValue = "0", required = false) @Parameter(description = "Requested offset of first record in returned collection of domain records.") final Long pageOffset, @RequestHeader(value = "Page-Limit", defaultValue = "10", required = false) @Parameter(description = "Requested limit to number of domain records returned.") final Long pageLimit, @RequestHeader(value = "Sort-Fields", required = false) @Parameter(description = "Comma separated list of one or more of the following fields - <b>code, description</b>") final String sortFields, @RequestHeader(value = "Sort-Order", defaultValue = "ASC", required = false) @Parameter(description = "Sort order (ASC or DESC) - defaults to ASC.") final Order sortOrder) {
         final var referenceCodes =
                 referenceDomainService.getReferenceCodesByDomain(
                         domain,
@@ -119,6 +119,17 @@ public class ReferenceDomainResource {
 
         return ResponseEntity.ok().headers(referenceCodes.getPaginationHeaders()).body(referenceCodes.getItems());
     }
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
+    @Operation(summary = "List of reference codes for reference domain.", description = "List of reference codes for reference domain ordered by code ascending. The list is an un-paged flat list")
+    @GetMapping("/domains/{domain}/codes")
+    public List<ReferenceCode> getReferenceCodesByDomain(@PathVariable("domain") @Parameter(description = "The domain identifier/name.", required = true) final String domain) {
+        return referenceDomainService.getReferenceCodesByDomain(domain);
+    }
+
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/ReferenceDomainService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/ReferenceDomainService.java
@@ -118,6 +118,12 @@ public class ReferenceDomainService {
                 domain, withSubCodes, getDefaultOrderBy(orderBy), getDefaultOrder(order), offset, limit);
     }
 
+    public List<ReferenceCode> getReferenceCodesByDomain(final String domain) {
+        verifyReferenceDomain(domain);
+
+        return referenceDataRepository.getReferenceCodesByDomain(domain, "code", Order.ASC);
+    }
+
     public Optional<ReferenceCode> getReferenceCodeByDomainAndCode(final String domain, final String code, final boolean withSubCodes) {
         verifyReferenceDomain(domain);
         verifyReferenceCode(domain, code);


### PR DESCRIPTION
The previous url was badly named as `/domains/{domain}` and also returns a paged result that almost certainly isn't required.

New url is `/domains/{domain}/codes`  and is unpaged. Also sub-codes is never returned since in live it is *never* requested