### PR TITLE
CRS-855 adding endpoint to get calculated dates in the same format th…

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderKeyDates.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderKeyDates.java
@@ -61,4 +61,7 @@ public class OffenderKeyDates {
 
     @Schema(required = true, description = "Sentence length in the format 00 years/00 months/00 days.", example = "11/00/00")
     private String sentenceLength;
+
+    @Schema(description = "Judicially imposed length in the format 00 years/00 months/00 days. Will default to 'sentenceLength'", example = "11/00/00")
+    private String judiciallyImposedSentenceLength;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderDatesResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderDatesResource.java
@@ -12,12 +12,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.hmpps.prison.api.model.ErrorResponse;
+import uk.gov.justice.hmpps.prison.api.model.OffenderKeyDates;
 import uk.gov.justice.hmpps.prison.api.model.RequestToUpdateOffenderDates;
 import uk.gov.justice.hmpps.prison.api.model.SentenceCalcDates;
 import uk.gov.justice.hmpps.prison.core.ProxyUser;
@@ -47,5 +49,21 @@ public class OffenderDatesResource {
                                                                     @RequestBody final RequestToUpdateOffenderDates requestToUpdateOffenderDates) {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(offenderDatesService.updateOffenderKeyDates(bookingId, requestToUpdateOffenderDates));
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Offender key dates found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = SentenceCalcDates.class))}),
+        @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "403", description = "Forbidden - user not authorised to update an offender's dates", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "Get the key dates for an offender.", description = "Requires RELEASE_DATES_CALCULATOR")
+    @GetMapping("/{bookingId}")
+    @PreAuthorize("hasRole('RELEASE_DATES_CALCULATOR')")
+    @ProxyUser
+    public ResponseEntity<OffenderKeyDates> getOffenderKeyDates(@PathVariable("bookingId") @Parameter(description = "The booking id of offender", required = true) final Long bookingId) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(offenderDatesService.getOffenderKeyDates(bookingId));
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.justice.hmpps.prison.api.model.OffenderKeyDates;
 import uk.gov.justice.hmpps.prison.api.model.RequestToUpdateOffenderDates;
 import uk.gov.justice.hmpps.prison.api.model.SentenceCalcDates;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.SentenceCalculation;
@@ -64,7 +65,8 @@ public class OffenderDatesService {
                 .tusedCalculatedDate(keyDatesFromPayload.getTopupSupervisionExpiryDate())
                 .effectiveSentenceEndDate(keyDatesFromPayload.getEffectiveSentenceEndDate())
                 .effectiveSentenceLength(keyDatesFromPayload.getSentenceLength())
-                .judiciallyImposedSentenceLength(keyDatesFromPayload.getSentenceLength())
+                .judiciallyImposedSentenceLength(keyDatesFromPayload.getJudiciallyImposedSentenceLength() != null ?
+                    keyDatesFromPayload.getJudiciallyImposedSentenceLength() : keyDatesFromPayload.getSentenceLength())
                 .build();
         offenderBooking.addSentenceCalculation(sentenceCalculation);
 
@@ -76,5 +78,29 @@ public class OffenderDatesService {
             ), null);
 
         return offenderBooking.getSentenceCalcDates(Optional.of(sentenceCalculation));
+    }
+
+    public OffenderKeyDates getOffenderKeyDates(Long bookingId) {
+        final var offenderBooking = offenderBookingRepository.findById(bookingId).orElseThrow(EntityNotFoundException.withId(bookingId));
+        final var sentenceCalculation = offenderBooking.getLatestCalculation().orElseThrow(EntityNotFoundException.withId(bookingId));;
+
+        return OffenderKeyDates.builder()
+            .homeDetentionCurfewEligibilityDate(sentenceCalculation.getHomeDetentionCurfewEligibilityDate())
+            .earlyTermDate(sentenceCalculation.getEarlyTermDate())
+            .midTermDate(sentenceCalculation.getMidTermDate())
+            .lateTermDate(sentenceCalculation.getLateTermDate())
+            .dtoPostRecallReleaseDate(sentenceCalculation.getDtoPostRecallReleaseDate())
+            .automaticReleaseDate(sentenceCalculation.getAutomaticReleaseDate())
+            .conditionalReleaseDate(sentenceCalculation.getConditionalReleaseDate())
+            .paroleEligibilityDate(sentenceCalculation.getParoleEligibilityDate())
+            .nonParoleDate(sentenceCalculation.getNonParoleDate())
+            .licenceExpiryDate(sentenceCalculation.getLicenceExpiryDate())
+            .postRecallReleaseDate(sentenceCalculation.getPostRecallReleaseDate())
+            .sentenceExpiryDate(sentenceCalculation.getSentenceExpiryDate())
+            .topupSupervisionExpiryDate(sentenceCalculation.getTopupSupervisionExpiryDate())
+            .effectiveSentenceEndDate(sentenceCalculation.getEffectiveSentenceEndDate())
+            .sentenceLength(sentenceCalculation.getEffectiveSentenceLength())
+            .judiciallyImposedSentenceLength(sentenceCalculation.getJudiciallyImposedSentenceLength())
+            .build();
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderDatesResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderDatesResourceTest.java
@@ -43,7 +43,7 @@ public class OffenderDatesResourceTest extends ResourceTest {
                 LocalDate.of(2021, 11, 4), LocalDate.of(2021, 11, 5), LocalDate.of(2021, 11, 6),
                 LocalDate.of(2021, 11, 7), LocalDate.of(2021, 11, 8), LocalDate.of(2021, 11, 9),
                 LocalDate.of(2021, 11, 10), LocalDate.of(2021, 11, 11), LocalDate.of(2021, 11, 12),
-                LocalDate.of(2021, 11, 13), LocalDate.of(2021, 11, 14),"11/00/00"))
+                LocalDate.of(2021, 11, 13), LocalDate.of(2021, 11, 14), "11/00/00", null))
             .submissionUser("ITAG_USER")
             .calculationUuid(UUID.randomUUID())
             .build();
@@ -70,7 +70,18 @@ public class OffenderDatesResourceTest extends ResourceTest {
             "A1234AB");
 
         assertThatJsonFileAndStatus(offenderSentenceResponse, 200, "sentence-after-offender-key-dates-update.json");
+
+        final var keyDatesAfterUpdate = testRestTemplate.exchange(
+            "/api/offender-dates/{bookingId}",
+            GET,
+            createHttpEntity(token, null),
+            new ParameterizedTypeReference<String>() {
+            },
+            Map.of("bookingId", BOOKING_ID));
+
+        assertThatJsonFileAndStatus(keyDatesAfterUpdate, 200, "offender-key-dates-after-update.json");
     }
+
 
     @Test
     public void testCantUpdateOffenderDatesWithInvalidBookingId() {
@@ -146,4 +157,6 @@ public class OffenderDatesResourceTest extends ResourceTest {
                 .userMessage("Access is denied")
                 .build());
     }
+
+
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.hmpps.prison.api.model.OffenderKeyDates;
 import uk.gov.justice.hmpps.prison.api.model.RequestToUpdateOffenderDates;
+import uk.gov.justice.hmpps.prison.api.model.v1.Booking;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderBooking;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.SentenceCalculation;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.Staff;
@@ -21,12 +22,14 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -165,13 +168,79 @@ public class OffenderDatesServiceTest {
             .hasMessage("Resource with id [staff] not found.");
     }
 
+    @Test
+    void getOffenderKeyDates_all_data_available() {
+        // Given
+        final var bookingId = 1L;
+        final var offenderBooking = OffenderBooking.builder()
+            .bookingId(bookingId)
+            .sentenceCalculations(List.of(
+                createSentenceCalculation()
+            ))
+            .build();
+        when(offenderBookingRepository.findById(bookingId)).thenReturn(Optional.of(offenderBooking));
+
+        // When
+        final var result = service.getOffenderKeyDates(bookingId);
+
+        // Then
+        assertEquals(result, createOffenderKeyDates());
+
+    }
+
+    public static SentenceCalculation createSentenceCalculation() {
+        return sentenceCalculation(
+            NOV_11_2021, NOV_11_2021, NOV_11_2021,
+            NOV_11_2021, NOV_11_2021, NOV_11_2021,
+            NOV_11_2021, NOV_11_2021, NOV_11_2021,
+            NOV_11_2021, NOV_11_2021, NOV_11_2021,
+            NOV_11_2021, NOV_11_2021, "11/00/00", "11/00/00");
+    }
+
     public static OffenderKeyDates createOffenderKeyDates() {
         return createOffenderKeyDates(
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
-            NOV_11_2021, NOV_11_2021, "11/00/00");
+            NOV_11_2021, NOV_11_2021, "11/00/00", "11/00/00");
+    }
+
+    public static SentenceCalculation sentenceCalculation(LocalDate homeDetentionCurfewEligibilityDate,
+                                                          LocalDate earlyTermDate,
+                                                          LocalDate midTermDate,
+                                                          LocalDate lateTermDate,
+                                                          LocalDate dtoPostRecallReleaseDate,
+                                                          LocalDate automaticReleaseDate,
+                                                          LocalDate conditionalReleaseDate,
+                                                          LocalDate paroleEligibilityDate,
+                                                          LocalDate nonParoleDate,
+                                                          LocalDate licenceExpiryDate,
+                                                          LocalDate postRecallReleaseDate,
+                                                          LocalDate sentenceExpiryDate,
+                                                          LocalDate topupSupervisionExpiryDate,
+                                                          LocalDate effectiveSentenceEndDate,
+                                                          String effectiveSentenceLength,
+                                                          String judiciallyImposedSentenceLength) {
+        return SentenceCalculation.builder()
+            .id(1L)
+            .hdcedCalculatedDate(homeDetentionCurfewEligibilityDate)
+            .etdCalculatedDate(earlyTermDate)
+            .mtdCalculatedDate(midTermDate)
+            .ltdCalculatedDate(lateTermDate)
+            .dprrdCalculatedDate(dtoPostRecallReleaseDate)
+            .ardCalculatedDate(automaticReleaseDate)
+            .crdCalculatedDate(conditionalReleaseDate)
+            .pedCalculatedDate(paroleEligibilityDate)
+            .npdCalculatedDate(nonParoleDate)
+            .ledCalculatedDate(licenceExpiryDate)
+            .prrdCalculatedDate(postRecallReleaseDate)
+            .sedCalculatedDate(sentenceExpiryDate)
+            .tusedCalculatedDate(topupSupervisionExpiryDate)
+            .effectiveSentenceEndDate(effectiveSentenceEndDate)
+            .effectiveSentenceLength(effectiveSentenceLength)
+            .judiciallyImposedSentenceLength(judiciallyImposedSentenceLength)
+            .build();
     }
 
     public static OffenderKeyDates createOffenderKeyDates(LocalDate homeDetentionCurfewEligibilityDate,
@@ -188,7 +257,8 @@ public class OffenderDatesServiceTest {
                                                           LocalDate sentenceExpiryDate,
                                                           LocalDate topupSupervisionExpiryDate,
                                                           LocalDate effectiveSentenceEndDate,
-                                                          String sentenceLength) {
+                                                          String sentenceLength,
+                                                          String judiciallyImposedSentenceLength) {
         return OffenderKeyDates.builder()
             .homeDetentionCurfewEligibilityDate(homeDetentionCurfewEligibilityDate)
             .earlyTermDate(earlyTermDate)
@@ -205,6 +275,7 @@ public class OffenderDatesServiceTest {
             .topupSupervisionExpiryDate(topupSupervisionExpiryDate)
             .effectiveSentenceEndDate(effectiveSentenceEndDate)
             .sentenceLength(sentenceLength)
+            .judiciallyImposedSentenceLength(judiciallyImposedSentenceLength)
             .build();
     }
 }

--- a/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/offender-key-dates-after-update.json
+++ b/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/offender-key-dates-after-update.json
@@ -1,0 +1,18 @@
+{
+  "homeDetentionCurfewEligibilityDate":"2021-11-01",
+  "earlyTermDate":"2021-11-02",
+  "midTermDate":"2021-11-03",
+  "lateTermDate":"2021-11-04",
+  "dtoPostRecallReleaseDate":"2021-11-05",
+  "automaticReleaseDate":"2021-11-06",
+  "conditionalReleaseDate":"2021-11-07",
+  "paroleEligibilityDate":"2021-11-08",
+  "nonParoleDate":"2021-11-09",
+  "licenceExpiryDate":"2021-11-10",
+  "postRecallReleaseDate":"2021-11-11",
+  "sentenceExpiryDate":"2021-11-12",
+  "topupSupervisionExpiryDate":"2021-11-13",
+  "effectiveSentenceEndDate":"2021-11-14",
+  "sentenceLength":"11/00/00",
+  "judiciallyImposedSentenceLength":"11/00/00"
+}


### PR DESCRIPTION
…at CRD sends.

The ESL and JSL are internal dates that NOMIS calculates. When CRD service calculates a release date we send over a sentence length that we've calculated. This sentence length is persisted to the ESL and JSL columns. This data is used in reporting and we need to support it.

This PR exposes the ESL and JSL so that we can compare the dates NOMIS calculates vs the dates CRD service calculates as part of our regression testing.