### PR TITLE
OFFENCES-81 Change offence related POST  and PUT endpoints to accept Lists rather than single objects

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenceResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenceResource.java
@@ -34,6 +34,7 @@ import uk.gov.justice.hmpps.prison.api.model.StatuteDto;
 import uk.gov.justice.hmpps.prison.service.reference.OffenceService;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 
 @RestController
@@ -76,7 +77,7 @@ public class OffenceResource {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
-    public Page<OffenceDto> getOffences(
+    public Page<OffenceDto> getOffencesThatStartWith(
         @Parameter(required = true, example = "AA1256A", description = "The offence code")
         @PathVariable("offenceCode")
         final String offenceCode,
@@ -122,55 +123,53 @@ public class OffenceResource {
     }
 
     @PostMapping("/ho-code")
-    @Operation(summary = "Create a Home Office Notifiable Offence Code record", description = "Requires OFFENCE_MAINTAINER role")
+    @Operation(summary = "Create Home Office Notifiable Offence Code records if they dont already exist", description = "Requires OFFENCE_MAINTAINER role")
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "Home Office Notifiable Offence Code created successfully"),
-        @ApiResponse(responseCode = "409", description = "A record already exists with the same Home Office Notifiable Offence Code", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "201", description = "Home Office Notifiable Offence Codes created successfully"),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @PreAuthorize("hasRole('OFFENCE_MAINTAINER') and hasAuthority('SCOPE_write')")
-    public ResponseEntity<Void> createHomeOfficeCode(@RequestBody final HOCodeDto hoCodeDto) {
-        log.info("Request received to create a Home Office Notifiable Offence Code: {}", hoCodeDto.getCode());
-        service.createHomeOfficeCode(hoCodeDto);
+    public ResponseEntity<Void> createHomeOfficeCodes(@RequestBody final List<HOCodeDto> hoCodes) {
+        log.info("Request received to create Home Office Notifiable Offence Codes");
+        service.createHomeOfficeCodes(hoCodes);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/statute")
-    @Operation(summary = "Create a Statute", description = "Requires OFFENCE_MAINTAINER role")
+    @Operation(summary = "Create statutes if they dont already exist", description = "Requires OFFENCE_MAINTAINER role")
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "Statute created successfully"),
-        @ApiResponse(responseCode = "409", description = "A record already exists with the same Home Office Notifiable Offence Code", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "201", description = "Statutes created successfully"),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @PreAuthorize("hasRole('OFFENCE_MAINTAINER') and hasAuthority('SCOPE_write')")
-    public ResponseEntity<Void> createStatute(@RequestBody final StatuteDto statuteDto) {
-        log.info("Request received to create a statute with code: {}", statuteDto.getCode());
-        service.createStatute(statuteDto);
+    public ResponseEntity<Void> createStatute(@RequestBody final List<StatuteDto> statutes) {
+        log.info("Request received to create a statutes");
+        service.createStatutes(statutes);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/offence")
-    @Operation(summary = "Create a offence", description = "Requires OFFENCE_MAINTAINER role")
+    @Operation(summary = "Create offences", description = "Requires OFFENCE_MAINTAINER role")
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "Offence created successfully"),
+        @ApiResponse(responseCode = "201", description = "Offences created successfully"),
         @ApiResponse(responseCode = "404", description = "A dependent resource is missing (either the statute or the home office code doesnt exist)", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-        @ApiResponse(responseCode = "409", description = "A record already exists with the same Offence Code", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "409", description = "A record already exists for a passed in offence", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @PreAuthorize("hasRole('OFFENCE_MAINTAINER') and hasAuthority('SCOPE_write')")
-    public ResponseEntity<Void> createOffence(@RequestBody final OffenceDto offenceDto) {
-        log.info("Request received to create a offence with code: {}", offenceDto.getCode());
-        service.createOffence(offenceDto);
+    public ResponseEntity<Void> createOffences(@RequestBody final List<OffenceDto> offences) {
+        log.info("Request received to create offences ");
+        service.createOffences(offences);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PutMapping("/offence")
-    @Operation(summary = "Update a offence", description = "Requires OFFENCE_MAINTAINER role")
+    @Operation(summary = "Update offences", description = "Requires OFFENCE_MAINTAINER role")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Offence updated successfully"),
         @ApiResponse(responseCode = "404", description = "A dependent resource is missing (either the offence or the home office code doesnt exist)", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @PreAuthorize("hasRole('OFFENCE_MAINTAINER') and hasAuthority('SCOPE_write')")
-    public ResponseEntity<Void> updateOffence(@RequestBody final OffenceDto offenceDto) {
-        log.info("Request received to update a offence with code: {}", offenceDto.getCode());
-        service.updateOffence(offenceDto);
+    public ResponseEntity<Void> updateOffences(@RequestBody final  List<OffenceDto> offences) {
+        log.info("Request received to update offences");
+        service.updateOffences(offences);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenceResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenceResourceTest.java
@@ -17,6 +17,7 @@ import uk.gov.justice.hmpps.prison.api.model.StatuteDto;
 import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class OffenceResourceTest extends ResourceTest {
     @Nested
@@ -131,26 +132,11 @@ public class OffenceResourceTest extends ResourceTest {
                 .code("123/45")
                 .description("123/45")
                 .build();
-            final var httpEntity = createHttpEntity(maintainerToken, hoCodeDto);
+            final var httpEntity = createHttpEntity(maintainerToken, List.of(hoCodeDto));
 
             final var response = postRequest(httpEntity, "/api/offences/ho-code");
 
             assertThatStatus(response, 201);
-        }
-
-        @Test
-        public void testDuplicateWriteHoCode() {
-            final var hoCodeDto = HOCodeDto
-                .builder()
-                .code("123/99")
-                .description("123/99")
-                .build();
-            final var httpEntity = createHttpEntity(maintainerToken, hoCodeDto);
-
-            final var response = postRequest(httpEntity, "/api/offences/ho-code");
-            assertThatStatus(response, 201);
-            final var duplicateResponse = postRequest(httpEntity, "/api/offences/ho-code");
-            assertThatStatus(duplicateResponse, 409);
         }
     }
 
@@ -167,27 +153,11 @@ public class OffenceResourceTest extends ResourceTest {
                 .description("123/45")
                 .legislatingBodyCode("UK")
                 .build();
-            final var httpEntity = createHttpEntity(maintainerToken, statuteDto);
+            final var httpEntity = createHttpEntity(maintainerToken, List.of(statuteDto));
 
             final var response = postRequest(httpEntity, "/api/offences/statute");
 
             assertThatStatus(response, 201);
-        }
-
-        @Test
-        public void testDuplicateWriteStatute() {
-            final var statuteDto = StatuteDto
-                .builder()
-                .code("123/99")
-                .description("123/99")
-                .legislatingBodyCode("UK")
-                .build();
-            final var httpEntity = createHttpEntity(maintainerToken, statuteDto);
-
-            final var response = postRequest(httpEntity, "/api/offences/statute");
-            assertThatStatus(response, 201);
-            final var duplicateResponse = postRequest(httpEntity, "/api/offences/statute");
-            assertThatStatus(duplicateResponse, 409);
         }
     }
 
@@ -224,9 +194,9 @@ public class OffenceResourceTest extends ResourceTest {
             config = @SqlConfig(transactionMode = TransactionMode.ISOLATED))
         @Test
         public void testCreateOffence() {
-            final var statuteHttpEntity = createHttpEntity(maintainerToken, statuteDto);
-            final var offenceHttpEntity = createHttpEntity(maintainerToken, offenceDto);
-            final var hoCodeEntity = createHttpEntity(maintainerToken, hoCodeDto);
+            final var statuteHttpEntity = createHttpEntity(maintainerToken, List.of(statuteDto));
+            final var offenceHttpEntity = createHttpEntity(maintainerToken, List.of(offenceDto));
+            final var hoCodeEntity = createHttpEntity(maintainerToken, List.of(hoCodeDto));
             postRequest(statuteHttpEntity, "/api/offences/statute");
             postRequest(hoCodeEntity, "/api/offences/ho-code");
 
@@ -257,7 +227,7 @@ public class OffenceResourceTest extends ResourceTest {
                 .activeFlag("N")
                 .expiryDate(LocalDate.of(2020, 10, 13))
                 .build();
-            final var offenceHttpEntity = createHttpEntity(maintainerToken, offenceDto);
+            final var offenceHttpEntity = createHttpEntity(maintainerToken, List.of(offenceDto));
 
             final var response = putRequest(offenceHttpEntity);
             assertThatStatus(response, 204);


### PR DESCRIPTION
Also, in the creation of statutes or ho_codes, do not throw a 409 exception if a record already exists with the same PK, instead just skip that record.