### PR TITLE
SDI-256 Ensure profiles with no code can be updated to prevent 2 rows being created.

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
@@ -483,6 +483,7 @@ public class OffenderBooking extends AuditableEntity {
 
     public List<OffenderProfileDetail> getActiveProfileDetails() {
         return profileDetails.stream()
+            .filter(pd -> Objects.nonNull(pd.getCode()))
             .filter(pd -> {
                 final var profileType = pd.getId().getType();
                 return profileType.getCategory().equals("PI") && (profileType.isActive() || profileType.getType().equals("RELF"));

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderProfileDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderProfileDetail.java
@@ -53,10 +53,10 @@ public class OffenderProfileDetail extends AuditableEntity {
         private Integer sequence;
     }
 
-    @ManyToOne(optional = false)
+    @ManyToOne
     @JoinColumns(value = {
         @JoinColumn(name = "PROFILE_CODE", referencedColumnName = "PROFILE_CODE", insertable = false, updatable = false),
-        @JoinColumn(name = "PROFILE_TYPE", referencedColumnName = "PROFILE_TYPE", nullable = false, insertable = false, updatable = false)
+        @JoinColumn(name = "PROFILE_TYPE", referencedColumnName = "PROFILE_TYPE", insertable = false, updatable = false)
     })
     @NotFound(action = IGNORE)
     private ProfileCode code;


### PR DESCRIPTION
Any row in OFFENDER_PROFILE_DETAILS with  a null code was accidentally not being read via JPA due to the mapping.
This change allows them to be read so that a row for YOUTH can be updated with the new code; without this both JPA and the NOMIS tore procedure will try to create the a row with the same primary key