### PR TITLE
SDI-259 Added a notion of BuilderContext

### DIFF
--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceNewBookingTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceNewBookingTest.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.hmpps.prison.repository.jpa.model.ExternalMovement
 import uk.gov.justice.hmpps.prison.repository.jpa.model.MovementDirection
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.BedAssignmentHistoriesRepository
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.ExternalMovementRepository
-import uk.gov.justice.hmpps.prison.service.DataLoaderRepository
 import uk.gov.justice.hmpps.prison.util.builders.OffenderBookingBuilder
 import uk.gov.justice.hmpps.prison.util.builders.OffenderBuilder
 import uk.gov.justice.hmpps.prison.util.builders.OffenderProfileDetailsBuilder
@@ -30,9 +29,6 @@ import java.time.format.DateTimeFormatter
 
 @WithMockUser
 class OffenderResourceNewBookingTest : ResourceTest() {
-  @Autowired
-  private lateinit var dataLoader: DataLoaderRepository
-
   @Autowired
   private lateinit var externalMovementRepository: ExternalMovementRepository
 
@@ -391,11 +387,7 @@ class OffenderResourceNewBookingTest : ResourceTest() {
       internal fun setUp() {
         OffenderBuilder(
           bookingBuilders = arrayOf()
-        ).save(
-          webTestClient = webTestClient,
-          jwtAuthenticationHelper = jwtAuthenticationHelper,
-          dataLoader = dataLoader
-        ).also {
+        ).save(builderContext).also {
           offenderNo = it.offenderNo
         }
       }
@@ -557,11 +549,7 @@ class OffenderResourceNewBookingTest : ResourceTest() {
             prisonId = "LEI",
             released = true,
           ).withProfileDetails(OffenderProfileDetailsBuilder("Y", ProfileType.YOUTH))
-        ).save(
-          webTestClient = webTestClient,
-          jwtAuthenticationHelper = jwtAuthenticationHelper,
-          dataLoader = dataLoader
-        ).also {
+        ).save(builderContext).also {
           offenderNo = it.offenderNo
         }
       }
@@ -717,11 +705,7 @@ class OffenderResourceNewBookingTest : ResourceTest() {
             prisonId = "LEI",
             released = true,
           ).withProfileDetails(OffenderProfileDetailsBuilder("N", ProfileType.YOUTH))
-        ).save(
-          webTestClient = webTestClient,
-          jwtAuthenticationHelper = jwtAuthenticationHelper,
-          dataLoader = dataLoader
-        ).also {
+        ).save(builderContext).also {
           offenderNo = it.offenderNo
         }
       }
@@ -1073,22 +1057,14 @@ class OffenderResourceNewBookingTest : ResourceTest() {
     OffenderBookingBuilder(
       prisonId = prisonId,
     )
-  ).save(
-    webTestClient = webTestClient,
-    jwtAuthenticationHelper = jwtAuthenticationHelper,
-    dataLoader = dataLoader
-  ).offenderNo
+  ).save(builderContext).offenderNo
 
   fun createInactiveBooking(iepLevel: String = "ENH"): String = OffenderBuilder().withBooking(
     OffenderBookingBuilder(
       prisonId = "MDI",
       released = true
     ).withIEPLevel(iepLevel)
-  ).save(
-    webTestClient = webTestClient,
-    jwtAuthenticationHelper = jwtAuthenticationHelper,
-    dataLoader = dataLoader
-  ).offenderNo
+  ).save(builderContext).offenderNo
 
   private fun getMovements(bookingId: Long) = externalMovementRepository.findAllByOffenderBooking_BookingId(bookingId)
   private fun getBedAssignments(bookingId: Long) =

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/ResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/ResourceTest.java
@@ -12,8 +12,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import uk.gov.justice.hmpps.prison.PrisonApiServer;
 import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper;
 import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken;
+import uk.gov.justice.hmpps.prison.service.DataLoaderRepository;
 import uk.gov.justice.hmpps.prison.util.JwtAuthenticationHelper;
 import uk.gov.justice.hmpps.prison.util.JwtParameters;
+import uk.gov.justice.hmpps.prison.util.builders.BuilderContext;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -30,6 +32,8 @@ import static org.springframework.core.ResolvableType.forType;
 @ActiveProfiles(value = "test")
 @SpringBootTest(webEnvironment = RANDOM_PORT, classes = PrisonApiServer.class)
 public abstract class ResourceTest {
+    @Autowired
+    private DataLoaderRepository dataLoader;
 
     @Autowired
     protected TestRestTemplate testRestTemplate;
@@ -42,6 +46,10 @@ public abstract class ResourceTest {
 
     @Autowired
     protected AuthTokenHelper authTokenHelper;
+
+    protected BuilderContext getBuilderContext() {
+        return new BuilderContext(webTestClient, jwtAuthenticationHelper, dataLoader);
+    }
 
     protected HttpEntity<?> createHttpEntity(final String bearerToken, final Object body) {
         return createHttpEntity(bearerToken, body, Collections.emptyMap());

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/ActivityTransferServiceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/ActivityTransferServiceIntTest.kt
@@ -29,9 +29,6 @@ import java.time.format.DateTimeFormatter
 @WithMockUser
 class ActivityTransferServiceIntTest : ResourceTest() {
   @Autowired
-  private lateinit var dataLoader: DataLoaderRepository
-
-  @Autowired
   private lateinit var transferService: ActivityTransferService
 
   @Nested
@@ -65,11 +62,7 @@ class ActivityTransferServiceIntTest : ResourceTest() {
               courseActivityId = -5
             )
           )
-      ).save(
-        webTestClient = webTestClient,
-        jwtAuthenticationHelper = jwtAuthenticationHelper,
-        dataLoader = dataLoader
-      ).also {
+      ).save(builderContext).also {
         offenderNo = it.offenderNo
         bookingId = it.bookingId
       }
@@ -80,8 +73,8 @@ class ActivityTransferServiceIntTest : ResourceTest() {
       val testEndDate = LocalDate.of(2022, 10, 1)
       transferOutToCourt(offenderNo, "COURT1", true)
 
-      val offenderBooking = dataLoader.offenderBookingRepository.findByBookingId(bookingId).orElseThrow()
-      val prison = dataLoader.agencyLocationRepository.findById("LEI").orElseThrow()
+      val offenderBooking = builderContext.dataLoader.offenderBookingRepository.findByBookingId(bookingId).orElseThrow()
+      val prison = builderContext.dataLoader.agencyLocationRepository.findById("LEI").orElseThrow()
 
       assertThat(
         getActiveActivities(
@@ -128,7 +121,7 @@ class ActivityTransferServiceIntTest : ResourceTest() {
     prison: AgencyLocation,
     testEndDate: LocalDate
   ): List<OffenderProgramProfile> =
-    dataLoader.offenderProgramProfileRepository.findActiveActivitiesForBookingAtPrison(
+    builderContext.dataLoader.offenderProgramProfileRepository.findActiveActivitiesForBookingAtPrison(
       offenderBooking, prison, testEndDate
     )
 
@@ -136,7 +129,7 @@ class ActivityTransferServiceIntTest : ResourceTest() {
     offenderBooking: OffenderBooking,
     prison: AgencyLocation
   ): List<OffenderProgramProfile> =
-    dataLoader.offenderProgramProfileRepository.findActiveWaitListActivitiesForBookingAtPrison(
+    builderContext.dataLoader.offenderProgramProfileRepository.findActiveWaitListActivitiesForBookingAtPrison(
       offenderBooking, prison
     )
 

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/DataLoaderRepository.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/DataLoaderRepository.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.hmpps.prison.service
 
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Service
-import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.hmpps.prison.repository.BookingRepository
 import uk.gov.justice.hmpps.prison.repository.jpa.model.CaseStatus
 import uk.gov.justice.hmpps.prison.repository.jpa.model.InstitutionArea
@@ -16,7 +15,7 @@ import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderProgramProf
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderTeamAssignmentRepository
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.ReferenceCodeRepository
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.TeamRepository
-import uk.gov.justice.hmpps.prison.util.JwtAuthenticationHelper
+import uk.gov.justice.hmpps.prison.util.builders.BuilderContext
 import uk.gov.justice.hmpps.prison.util.builders.OffenderBuilder
 import uk.gov.justice.hmpps.prison.util.builders.TeamBuilder
 import javax.transaction.Transactional
@@ -36,24 +35,23 @@ class DataLoaderRepository(
   val institutionAreaRepository: ReferenceCodeRepository<InstitutionArea>,
   val teamCategoryRepository: ReferenceCodeRepository<TeamCategory>,
   val jdbcTemplate: JdbcTemplate,
-) {
+)
+
+@Service
+class DataLoaderTransaction {
   @Transactional
   fun load(
     offenderBuilder: OffenderBuilder,
-    webTestClient: WebTestClient,
-    jwtAuthenticationHelper: JwtAuthenticationHelper
+    builderContext: BuilderContext,
   ) =
-    offenderBuilder.save(
-      webTestClient = webTestClient,
-      jwtAuthenticationHelper = jwtAuthenticationHelper,
-      dataLoader = this
-    )
+    offenderBuilder.save(builderContext)
 
   @Transactional
   fun load(
     teamBuilder: TeamBuilder,
+    builderContext: BuilderContext,
   ) =
     teamBuilder.save(
-      dataLoader = this
+      dataLoader = builderContext.dataLoader
     )
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/util/builders/BuilderHelpers.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/util/builders/BuilderHelpers.kt
@@ -1,4 +1,8 @@
-package uk.gov.justice.hmpps.prison.util
+package uk.gov.justice.hmpps.prison.util.builders
+
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.hmpps.prison.service.DataLoaderRepository
+import uk.gov.justice.hmpps.prison.util.JwtAuthenticationHelper
 
 internal fun randomName(): String {
   // return random name between 3 and 10 characters long
@@ -6,3 +10,9 @@ internal fun randomName(): String {
     ('a' + (Math.random() * 26).toInt())
   }.joinToString("")
 }
+
+data class BuilderContext(
+  val webTestClient: WebTestClient,
+  val jwtAuthenticationHelper: JwtAuthenticationHelper,
+  val dataLoader: DataLoaderRepository
+)

--- a/src/test/java/uk/gov/justice/hmpps/prison/util/builders/OffenderBuilder.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/util/builders/OffenderBuilder.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.hmpps.prison.api.model.InmateDetail
 import uk.gov.justice.hmpps.prison.api.model.RequestToCreate
 import uk.gov.justice.hmpps.prison.service.DataLoaderRepository
 import uk.gov.justice.hmpps.prison.util.JwtAuthenticationHelper
-import uk.gov.justice.hmpps.prison.util.randomName
 import java.time.LocalDate
 
 class OffenderBuilder(
@@ -34,6 +33,9 @@ class OffenderBuilder(
   }
 
   fun save(
+    builderContext: BuilderContext
+  ): InmateDetail = save(builderContext.webTestClient, builderContext.jwtAuthenticationHelper, builderContext.dataLoader)
+  private fun save(
     webTestClient: WebTestClient,
     jwtAuthenticationHelper: JwtAuthenticationHelper,
     dataLoader: DataLoaderRepository,


### PR DESCRIPTION
So that we can add helpers using extensions rather then polluting the base ResourceTest class added builder context that has everything you would ever need to add or retrieve data.

Next step is to add some extensions e.g `releasePrisoner` so that it can be shared between tests