### PR TITLE
INC-647 From Agency location is not updated on an external movement update for an already released prisoner

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/RequestToDischargePrisoner.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/RequestToDischargePrisoner.java
@@ -32,12 +32,11 @@ public class RequestToDischargePrisoner {
     @Length(max = 240, message = "Comments size is a maximum of 240 characters")
     private String commentText;
 
-    @Schema(description = "Supporting Prison for POM, can be null if prisoner is already in a prison", example = "MDI")
+    @Schema(description = "Supporting Prison for POM, can be null if prisoner is already in a prison, for prisoners already released this field will be ignored", example = "MDI")
     @Length(max = 3, message = "Prison ID is 3 character code")
-    @NotNull
     private String supportingPrisonId;
 
-    @Schema(description = "Where the prisoner has moved from e.g. court, can be null if prisoner is already in prison", example = "SHEFCC")
+    @Schema(description = "Where the prisoner has moved from e.g. court, can be null if prisoner is already in prison, for prisoners already in prison this field will be ignored", example = "SHEFCC")
     @Length(max = 6, message = "From location")
     private String fromLocationId;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerReleaseAndTransferService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerReleaseAndTransferService.java
@@ -199,7 +199,6 @@ public class PrisonerReleaseAndTransferService {
             lastMovement.setMovementReason(movementReasonRepository.findById(DISCHARGE_TO_PSY_HOSPITAL).orElseThrow(EntityNotFoundException.withMessage(format("No movement reason %s found", DISCHARGE_TO_PSY_HOSPITAL))));
             lastMovement.setToAgency(toLocation);
             lastMovement.setCommentText(commentText);
-            lastMovement.setFromAgency(agencyLocationRepository.findById(requestToDischargePrisoner.getSupportingPrisonId()).orElseThrow(EntityNotFoundException.withMessage(format("No %s agency found", requestToDischargePrisoner.getSupportingPrisonId()))));
             offenderBooking.setStatusReason(REL.getCode() + "-" + DISCHARGE_TO_PSY_HOSPITAL.getCode());
         } else {
             releasePrisoner(prisonerIdentifier, RequestToReleasePrisoner.builder()

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTest.java
@@ -15,14 +15,20 @@ import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper
 import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken;
 
 import java.math.BigDecimal;
-import java.time.*;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpMethod.*;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
 import static uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken.PRISON_API_USER;
 
 @ContextConfiguration(classes = OffendersResourceTest.TestClock.class)
@@ -627,7 +633,7 @@ public class OffendersResourceTest extends ResourceTest {
 
         assertThatOKResponseContainsJson(response, """
               {
-                  "locationDescription": "Outside - released from SHREWSBURY (HMP)",
+                  "locationDescription": "Outside - released from SHREWSBURY",
                   "latestLocationId": "SYI"
               }
             """);

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTest.java
@@ -15,20 +15,14 @@ import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper
 import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken;
 
 import java.math.BigDecimal;
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.*;
 import static uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken.PRISON_API_USER;
 
 @ContextConfiguration(classes = OffendersResourceTest.TestClock.class)
@@ -598,9 +592,7 @@ public class OffendersResourceTest extends ResourceTest {
         final var dischargeRequest = Map.of(
             "hospitalLocationCode", "HAZLWD",
             "dischargeTime", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
-            "commentText", "Discharged to Psychiatric hospital",
-            "supportingPrisonId", "LEI",
-            "fromLocationId", "COURT1");
+            "commentText", "Discharged to Psychiatric hospital");
         final var dischargeEntity = createHttpEntity(token, dischargeRequest);
 
         final var dischargeResponse =  testRestTemplate.exchange(
@@ -635,8 +627,8 @@ public class OffendersResourceTest extends ResourceTest {
 
         assertThatOKResponseContainsJson(response, """
               {
-                  "locationDescription": "Outside - released from LEEDS",
-                  "latestLocationId": "LEI"
+                  "locationDescription": "Outside - released from SHREWSBURY (HMP)",
+                  "latestLocationId": "SYI"
               }
             """);
 

--- a/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/movement_discharge_2.json
+++ b/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/movement_discharge_2.json
@@ -1,5 +1,5 @@
 {
-  "fromAgency": "LEI",
+  "fromAgency": "SYI",
   "toAgency": "HAZLWD",
   "toAgencyDescription": "Hazelwood House",
   "movementType": "REL",


### PR DESCRIPTION
Currently, the RP API calls discharge to hospital for releasing prisoners IN prison. But it also handles prisoners released but fixes up the existing external movement if the `to agency` is incorrect.  This is use in the migration process or correction of an incorrectly NOMIS released RP prisoner.  The `from agency` SHOULD NOT be corrected as it break MPC / prisoner indexer if the location is not a prison which will be the case if the `supportingLocationId` is OUT. It also makes no sense to change the `fromLocation` without also changing the previous external IN movements to match, otherwise the prisoner will look like they have magically JUMPED to a new prison before being released.