### PR TITLE
SDI-352 Example of how to set the Nomis context to ignore Xtag events

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import static java.lang.String.format;
 import static uk.gov.justice.hmpps.prison.security.AuthSource.NOMIS;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.IP_ADDRESS;
+import static uk.gov.justice.hmpps.prison.util.MdcUtility.NOMIS_CONTEXT;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.PROXY_USER;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.REQUEST_URI;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.USER_ID_HEADER;
@@ -107,7 +108,7 @@ public class OracleConnectionAspect extends AbstractConnectionAspect {
                 nomis_context.set_context('AUDIT_USER_ID', '%s');
                 nomis_context.set_client_nomis_context('%s', '%s', '%s', '%s');
                 END;""",
-                AppModuleName.PRISON_API,
+                MDC.get(NOMIS_CONTEXT),
                 MDC.get(USER_ID_HEADER),
                 MDC.get(USER_ID_HEADER),
                 MDC.get(IP_ADDRESS),

--- a/src/main/java/uk/gov/justice/hmpps/prison/util/MdcUtility.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/util/MdcUtility.java
@@ -13,6 +13,7 @@ public class MdcUtility {
     public static final String PROXY_USER = "proxy-user";
     public static final String IP_ADDRESS = "clientIpAddress";
     public static final String REQUEST_URI = "request-url";
+    public static final String NOMIS_CONTEXT = "nomis-context";
 
     public static boolean isLoggingAllowed() {
         return !"true".equals(MDC.get(SKIP_LOGGING));

--- a/src/main/java/uk/gov/justice/hmpps/prison/web/filter/NomisContextFilter.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/web/filter/NomisContextFilter.java
@@ -1,0 +1,61 @@
+package uk.gov.justice.hmpps.prison.web.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
+
+import static uk.gov.justice.hmpps.prison.aop.connectionproxy.AppModuleName.MERGE;
+import static uk.gov.justice.hmpps.prison.aop.connectionproxy.AppModuleName.PRISON_API;
+import static uk.gov.justice.hmpps.prison.util.MdcUtility.NOMIS_CONTEXT;
+
+
+@Component
+@Slf4j
+public class NomisContextFilter implements Filter {
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS");
+
+    private final Pattern excludeUriRegex;
+
+    @Autowired
+    public NomisContextFilter(@Value("${logging.uris.exclude.regex}") final String excludeUris) {
+        excludeUriRegex = Pattern.compile(excludeUris);
+    }
+
+    @Override
+    public void init(final FilterConfig filterConfig) {
+
+    }
+
+    @Override
+    public void doFilter(
+            final ServletRequest request,
+            final ServletResponse response,
+            final FilterChain chain) throws IOException, ServletException {
+
+        MDC.put(NOMIS_CONTEXT, PRISON_API.name());
+        final var req = (HttpServletRequest) request;
+        if ("true".equals(req.getHeader("no-xtag-events"))) {
+            MDC.put(NOMIS_CONTEXT, MERGE.name());
+        }
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}


### PR DESCRIPTION
The idea is that when calling an endpoint that updates Nomis you can send in a header on the request (in this example "no-xtag-events" -> "true") to indicate we want to use the Nomis MERGE context instead of the PRISON_API context. This then triggers a bunch of defensive clauses in various XTAG generating stored procedures to prevent the XTAG event from being generated.

This has been tested with the endpoint `/offenders/{offenderNo}/discharge-to-hospital` and it did indeed prevent any XTAG events from being raised.

Note that to test this running locally you'll need to configure the replica database otherwise the OracleConnectionAspect is never fired.