### PR TITLE
SDI-378 Fix null pointer when calculating PrisonerPeriod

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/Offender.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/Offender.java
@@ -216,7 +216,7 @@ public class Offender extends AuditableEntity {
         final var externalMovements = new ArrayList<ExternalMovement>();
         bookings.forEach(b -> externalMovements.addAll(b.getExternalMovements()));
         return externalMovements.stream()
-            .sorted(Comparator.comparing(ExternalMovement::getMovementTime))
+            .sorted(Comparator.comparing(ExternalMovement::getMovementSequence))
             .toList();
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
@@ -513,7 +513,6 @@ public class OffenderBooking extends AuditableEntity {
     }
 
     public ExternalMovement addExternalMovement(final ExternalMovement externalMovement) {
-        externalMovement.setMovementSequence(getNextMovementSequence());
         externalMovement.setOffenderBooking(this);
         externalMovements.add(externalMovement);
         return externalMovement;
@@ -555,10 +554,6 @@ public class OffenderBooking extends AuditableEntity {
 
     public Long getNextImprisonmentStatusSequence() {
         return getImprisonmentStatusesRecentFirst().stream().findFirst().map(OffenderImprisonmentStatus::getImprisonStatusSeq).orElse(0L) + 1;
-    }
-
-    public Long getNextMovementSequence() {
-        return getLastMovement().map(ExternalMovement::getMovementSequence).orElse(0L) + 1;
     }
 
     public void setPreviousMovementsToInactive() {

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
@@ -513,6 +513,7 @@ public class OffenderBooking extends AuditableEntity {
     }
 
     public ExternalMovement addExternalMovement(final ExternalMovement externalMovement) {
+        externalMovement.setMovementSequence(getNextMovementSequence());
         externalMovement.setOffenderBooking(this);
         externalMovements.add(externalMovement);
         return externalMovement;
@@ -554,6 +555,10 @@ public class OffenderBooking extends AuditableEntity {
 
     public Long getNextImprisonmentStatusSequence() {
         return getImprisonmentStatusesRecentFirst().stream().findFirst().map(OffenderImprisonmentStatus::getImprisonStatusSeq).orElse(0L) + 1;
+    }
+
+    public Long getNextMovementSequence() {
+        return getLastMovement().map(ExternalMovement::getMovementSequence).orElse(0L) + 1;
     }
 
     public void setPreviousMovementsToInactive() {

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
@@ -112,20 +112,20 @@ public class OffenderBookingTest {
 
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementType(new MovementType("REL", "Release"))
-                    .movementDirection(MovementDirection.OUT)
-                    .movementReason(new MovementReason("CR", "Conditional Release"))
-                    .movementTime(LocalDateTime.of(2019, 2, 28, 15, 30))
-                    .build()
-            );
-            booking1.addExternalMovement(
-                ExternalMovement.builder()
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("B", "Recall"))
                     .movementTime(LocalDateTime.of(2019, 1, 4, 9, 30))
                     .toAgency(AgencyLocation.builder().id("WWI").build())
                     .build());
+            booking1.addExternalMovement(
+                ExternalMovement.builder()
+                    .movementType(new MovementType("REL", "Release"))
+                    .movementDirection(MovementDirection.OUT)
+                    .movementReason(new MovementReason("CR", "Conditional Release"))
+                    .movementTime(LocalDateTime.of(2019, 2, 28, 15, 30))
+                    .build()
+            );
 
 
             final var booking2 = OffenderBooking.builder()
@@ -144,16 +144,16 @@ public class OffenderBookingTest {
             booking2.addExternalMovement(
                 ExternalMovement.builder()
                     .movementType(new MovementType("TAP", "Temp Ab"))
-                    .movementDirection(MovementDirection.IN)
+                    .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("C4", "Wedding"))
-                    .movementTime(LocalDateTime.of(2020, 1, 15, 15, 30))
+                    .movementTime(LocalDateTime.of(2020, 1, 15, 9, 30))
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
                     .movementType(new MovementType("TAP", "Temp Ab"))
-                    .movementDirection(MovementDirection.OUT)
+                    .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("C4", "Wedding"))
-                    .movementTime(LocalDateTime.of(2020, 1, 15, 9, 30))
+                    .movementTime(LocalDateTime.of(2020, 1, 15, 15, 30))
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
@@ -171,10 +171,11 @@ public class OffenderBookingTest {
 
             booking3.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementType(new MovementType("CRT", "Court"))
+                    .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
-                    .movementReason(new MovementReason("CRT", "Court Appearance"))
-                    .movementTime(LocalDateTime.of(2021, 1, 15, 15, 30))
+                    .movementReason(new MovementReason("B", "Recall"))
+                    .movementTime(LocalDateTime.of(2021, 1, 4, 9, 30))
+                    .toAgency(AgencyLocation.builder().id("MDI").build())
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
@@ -185,11 +186,10 @@ public class OffenderBookingTest {
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementType(new MovementType("ADM", "Admission"))
+                    .movementType(new MovementType("CRT", "Court"))
                     .movementDirection(MovementDirection.IN)
-                    .movementReason(new MovementReason("B", "Recall"))
-                    .movementTime(LocalDateTime.of(2021, 1, 4, 9, 30))
-                    .toAgency(AgencyLocation.builder().id("MDI").build())
+                    .movementReason(new MovementReason("CRT", "Court Appearance"))
+                    .movementTime(LocalDateTime.of(2021, 1, 15, 15, 30))
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
@@ -112,6 +112,7 @@ public class OffenderBookingTest {
 
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(2L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("CR", "Conditional Release"))
@@ -120,6 +121,7 @@ public class OffenderBookingTest {
             );
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("B", "Recall"))
@@ -135,6 +137,7 @@ public class OffenderBookingTest {
 
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("25", "Awaiting Sentence"))
@@ -143,6 +146,7 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(3L)
                     .movementType(new MovementType("TAP", "Temp Ab"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("C4", "Wedding"))
@@ -150,6 +154,7 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(2L)
                     .movementType(new MovementType("TAP", "Temp Ab"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("C4", "Wedding"))
@@ -157,6 +162,7 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("BL", "Bailed"))
@@ -171,6 +177,7 @@ public class OffenderBookingTest {
 
             booking3.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(3L)
                     .movementType(new MovementType("CRT", "Court"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("CRT", "Court Appearance"))
@@ -178,6 +185,7 @@ public class OffenderBookingTest {
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(2L)
                     .movementType(new MovementType("CRT", "Court"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("CRT", "Court Appearance"))
@@ -185,6 +193,7 @@ public class OffenderBookingTest {
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("B", "Recall"))
@@ -193,6 +202,7 @@ public class OffenderBookingTest {
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("HP", "Hospital"))
@@ -245,6 +255,7 @@ public class OffenderBookingTest {
 
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("B", "Recall"))
@@ -253,6 +264,7 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(2L)
                     .movementType(new MovementType("TRN", "Transfer"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("NOTR", "Transfer"))
@@ -262,6 +274,7 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(3L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("INT", "Transfer"))
@@ -271,6 +284,7 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("CR", "Conditional Release"))
@@ -313,6 +327,7 @@ public class OffenderBookingTest {
             // A straight forward booking and release - needed to have >1 bookings to trigger the comparator
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("I", "In"))
@@ -321,6 +336,7 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(2L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("AR", "Actual Release"))
@@ -333,6 +349,7 @@ public class OffenderBookingTest {
             // Previously this caused null PrisonPeriod.entryDate which blows up the comparator at the end of OffenderBooking#getPrisonerInPrisonSummary
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("I", "In"))
@@ -341,6 +358,7 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(2L)
                     .movementType(new MovementType("TAP", "Temporary Absence"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("C5", "C5"))
@@ -349,6 +367,7 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(3L)
                     .movementType(new MovementType("TAP", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("C5", "C5"))
@@ -357,6 +376,7 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
+                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("AR", "Actual Release"))

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
@@ -112,7 +112,6 @@ public class OffenderBookingTest {
 
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(2L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("CR", "Conditional Release"))
@@ -121,7 +120,6 @@ public class OffenderBookingTest {
             );
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("B", "Recall"))
@@ -137,7 +135,6 @@ public class OffenderBookingTest {
 
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("25", "Awaiting Sentence"))
@@ -146,7 +143,6 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(3L)
                     .movementType(new MovementType("TAP", "Temp Ab"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("C4", "Wedding"))
@@ -154,7 +150,6 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(2L)
                     .movementType(new MovementType("TAP", "Temp Ab"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("C4", "Wedding"))
@@ -162,7 +157,6 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("BL", "Bailed"))
@@ -177,7 +171,6 @@ public class OffenderBookingTest {
 
             booking3.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(3L)
                     .movementType(new MovementType("CRT", "Court"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("CRT", "Court Appearance"))
@@ -185,7 +178,6 @@ public class OffenderBookingTest {
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(2L)
                     .movementType(new MovementType("CRT", "Court"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("CRT", "Court Appearance"))
@@ -193,7 +185,6 @@ public class OffenderBookingTest {
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("B", "Recall"))
@@ -202,7 +193,6 @@ public class OffenderBookingTest {
                     .build());
             booking3.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("HP", "Hospital"))
@@ -255,7 +245,6 @@ public class OffenderBookingTest {
 
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("B", "Recall"))
@@ -264,7 +253,6 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(2L)
                     .movementType(new MovementType("TRN", "Transfer"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("NOTR", "Transfer"))
@@ -274,7 +262,6 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(3L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("INT", "Transfer"))
@@ -284,7 +271,6 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("CR", "Conditional Release"))
@@ -327,7 +313,6 @@ public class OffenderBookingTest {
             // A straight forward booking and release - needed to have >1 bookings to trigger the comparator
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("I", "In"))
@@ -336,7 +321,6 @@ public class OffenderBookingTest {
                     .build());
             booking1.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(2L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("AR", "Actual Release"))
@@ -349,7 +333,6 @@ public class OffenderBookingTest {
             // Previously this caused null PrisonPeriod.entryDate which blows up the comparator at the end of OffenderBooking#getPrisonerInPrisonSummary
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(1L)
                     .movementType(new MovementType("ADM", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("I", "In"))
@@ -358,7 +341,6 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(2L)
                     .movementType(new MovementType("TAP", "Temporary Absence"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("C5", "C5"))
@@ -367,7 +349,6 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(3L)
                     .movementType(new MovementType("TAP", "Admission"))
                     .movementDirection(MovementDirection.IN)
                     .movementReason(new MovementReason("C5", "C5"))
@@ -376,7 +357,6 @@ public class OffenderBookingTest {
                     .build());
             booking2.addExternalMovement(
                 ExternalMovement.builder()
-                    .movementSequence(4L)
                     .movementType(new MovementType("REL", "Release"))
                     .movementDirection(MovementDirection.OUT)
                     .movementReason(new MovementReason("AR", "Actual Release"))

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBookingTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class OffenderBookingTest {
     private static final OffenderCourtCase ACTIVE_COURT_CASE = OffenderCourtCase.builder()
@@ -288,6 +289,91 @@ public class OffenderBookingTest {
             assertThat(prisonerInPrisonSummary.getPrisonPeriod().get(0).getEntryDate()).isEqualTo(LocalDateTime.of(2019, 1, 4, 9, 30));
             assertThat(prisonerInPrisonSummary.getPrisonPeriod().get(0).getReleaseDate()).isEqualTo(LocalDateTime.of(2019, 2, 28, 15, 30));
             assertThat(prisonerInPrisonSummary.getPrisonPeriod().get(0).getPrisons()).containsExactly("MDI", "WWI");
+
+        }
+
+        @DisplayName(value = "handles TAPs with dates out of sync")
+        @Test
+        void HandleOutOfSyncTaps() {
+
+            final var offender = Offender.builder()
+                .nomsId("A1234AA")
+                .build();
+
+            offender.setRootOffender(offender);
+            final var booking1 = OffenderBooking.builder()
+                .bookingId(54321L)
+                .bookNumber("R4312K")
+                .build();
+            final var booking2 = OffenderBooking.builder()
+                .bookingId(12345L)
+                .bookNumber("R1234K")
+                .build();
+
+            // A straight forward booking and release - needed to have >1 bookings to trigger the comparator
+            booking1.addExternalMovement(
+                ExternalMovement.builder()
+                    .movementType(new MovementType("ADM", "Admission"))
+                    .movementDirection(MovementDirection.IN)
+                    .movementReason(new MovementReason("I", "In"))
+                    .movementTime(LocalDateTime.of(2018, 1, 4, 9, 30))
+                    .toAgency(AgencyLocation.builder().id("MDI").build())
+                    .build());
+            booking1.addExternalMovement(
+                ExternalMovement.builder()
+                    .movementType(new MovementType("REL", "Release"))
+                    .movementDirection(MovementDirection.OUT)
+                    .movementReason(new MovementReason("AR", "Actual Release"))
+                    .movementTime(LocalDateTime.of(2018, 2, 28, 15, 30))
+                    .fromAgency(AgencyLocation.builder().id("MDI").build())
+                    .toAgency(AgencyLocation.builder().id("OUT").build())
+                    .build());
+
+            // This booking has the TAP dates out of order - as seen in real data
+            // Previously this caused null PrisonPeriod.entryDate which blows up the comparator at the end of OffenderBooking#getPrisonerInPrisonSummary
+            booking2.addExternalMovement(
+                ExternalMovement.builder()
+                    .movementType(new MovementType("ADM", "Admission"))
+                    .movementDirection(MovementDirection.IN)
+                    .movementReason(new MovementReason("I", "In"))
+                    .movementTime(LocalDateTime.of(2019, 1, 4, 9, 30))
+                    .toAgency(AgencyLocation.builder().id("MDI").build())
+                    .build());
+            booking2.addExternalMovement(
+                ExternalMovement.builder()
+                    .movementType(new MovementType("TAP", "Temporary Absence"))
+                    .movementDirection(MovementDirection.OUT)
+                    .movementReason(new MovementReason("C5", "C5"))
+                    .movementTime(LocalDateTime.of(2019, 1, 7, 12, 15))
+                    .fromAgency(AgencyLocation.builder().id("MDI").build())
+                    .build());
+            booking2.addExternalMovement(
+                ExternalMovement.builder()
+                    .movementType(new MovementType("TAP", "Admission"))
+                    .movementDirection(MovementDirection.IN)
+                    .movementReason(new MovementReason("C5", "C5"))
+                    .movementTime(LocalDateTime.of(2019, 1, 5, 10, 00))
+                    .toAgency(AgencyLocation.builder().id("MDI").build())
+                    .build());
+            booking2.addExternalMovement(
+                ExternalMovement.builder()
+                    .movementType(new MovementType("REL", "Release"))
+                    .movementDirection(MovementDirection.OUT)
+                    .movementReason(new MovementReason("AR", "Actual Release"))
+                    .movementTime(LocalDateTime.of(2019, 2, 28, 15, 30))
+                    .fromAgency(AgencyLocation.builder().id("MDI").build())
+                    .toAgency(AgencyLocation.builder().id("OUT").build())
+                    .build());
+
+            offender.addBooking(booking1);
+            offender.addBooking(booking2);
+
+            assertThatNoException().isThrownBy(() -> {
+                final var prisonerInPrisonSummary = offender.getPrisonerInPrisonSummary();
+
+                assertThat(prisonerInPrisonSummary.getPrisonPeriod().get(1).getEntryDate()).isNotNull();
+                assertThat(prisonerInPrisonSummary.getPrisonPeriod().get(1).getReleaseDate()).isNotNull();
+            });
 
         }
     }


### PR DESCRIPTION
It turns out there is some old bad data in NOMIS where the release movement time is before the admission movement time (seems particularly prevalent around TAPs). This caused movements to be processed out of sequence when calculating the PrisonerInPrisonSummary. The fix being to process the movements in sequence order rather than movement time order.