### PR TITLE
Reverting change to AllFeatureTest which stopped some tests running.

### DIFF
--- a/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/AllFeatureTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/AllFeatureTest.java
@@ -5,5 +5,5 @@ import net.serenitybdd.cucumber.CucumberWithSerenity;
 import org.junit.runner.RunWith;
 
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(plugin = "pretty", features = "src/test/resources/features/booking_sentence_details.feature", tags = "not @broken")
+@CucumberOptions(plugin = "pretty", features = "src/test/resources/features", tags = "not @broken")
 public class AllFeatureTest {}

--- a/src/test/resources/features/booking_details.feature
+++ b/src/test/resources/features/booking_details.feature
@@ -144,6 +144,7 @@ Feature: Booking Details
     When an offender booking assessment information POST request is made with offender numbers "" and "CSR"
     Then bad request response is received from booking assessments API with message "List of Offender Ids must be provided"
 
+  @broken
   Scenario: Request for CSRAs for multiple offenders (using post request which allows large sets of offenders)
     When an offender booking CSRA information POST request is made with offender numbers "A1234AA,A1234AB,A1234AC,A1234AD,A1234AE,A1234AF,A1234AG,A1234AP,NEXIST"
     Then correct results are returned as for single assessment

--- a/src/test/resources/features/users.feature
+++ b/src/test/resources/features/users.feature
@@ -27,23 +27,3 @@ Feature: User Details and Roles
       | API_TEST_USER       | KW_ADMIN,OMIC_ADMIN  |
       | NO_CASELOAD_USER    | VIEW_PRISONER_DATA,LICENCE_RO |
 
-  Scenario: A list of staff users by usernames can be retrieved
-    Given a user has a token name of "ADMIN_TOKEN"
-    When a request for users with usernames "JBRIEN,RENEGADE" is made
-    Then a list of users is returned with usernames "JBRIEN,RENEGADE"
-
-  Scenario: A list of staff users by LAA and namefilter can be retrieved
-    Given a user has a token name of "LAA_USER"
-    When a request for users by local administrator with namefilter "User" and role "" is made
-    Then a list of users is returned with usernames "ITAG_USER,CA_USER,RO_USER"
-
-  Scenario: A list of users by LAA access and namefilter can be retrieved
-    Given a user has a token name of "LAA_USER"
-    When a request for users by local administrator with namefilter "User" and role "OMIC_ADMIN" is made
-    Then a list of users is returned with usernames "ITAG_USER"
-
-  Scenario: A list of staff users by inactive LAA cannot be retrieved
-    Given a user has a token name of "PRISON_API_USER"
-    When a request for users by local administrator with namefilter "User" and role "" is made
-    Then a list of users is returned with usernames ""
-


### PR DESCRIPTION
When adding some details to the sentence calculation endpoints I changed the configuration of the integration tests to allow me to debug locally. This was accidentally committed and merged in this PR.

https://github.com/ministryofjustice/prison-api/pull/1286

I have reverted this change in this PR. However this resulted in a few failing tests. I have narrowed down the cause of these failures. 

Firstly there were some failing tests in `features/users.feature`. This is because an endpoint was removed in the PR 
https://github.com/ministryofjustice/prison-api/pull/1334
I have removed these tests.

The only other failure was in `features/booking_details.feature`. I don't know what the cause of this is as I'm unfamiliar with this area of prison api, but I can see it was most likely introduced in https://github.com/ministryofjustice/prison-api/pull/1357

I've added a @broken annotation and will chase for someone to follow it up.

