### PR TITLE
NN-4508 remove prisoner from test as data is setup incorrectly

### DIFF
--- a/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/steps/BookingAssessmentSteps.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/executablespecification/steps/BookingAssessmentSteps.java
@@ -225,7 +225,6 @@ public class BookingAssessmentSteps extends CommonSteps {
                 .extracting("bookingId", "offenderNo", "classification", "assessmentCode", "cellSharingAlertFlag", "nextReviewDate")
                 .contains(tuple(-1L, "A1234AA", "High", "CSR", true, LocalDate.of(2018, Month.JUNE, 1)),
                         tuple(-3L, "A1234AC", "Low", "CSR", true, LocalDate.of(2018, Month.JUNE, 3)),
-                        tuple(-4L, "A1234AD", "Medium", "CSR", true, LocalDate.of(2018, Month.JUNE, 4)),
                         tuple(-5L, "A1234AE", "High", "CSR", true, LocalDate.of(2018, Month.JUNE, 5)),
                         tuple(-6L, "A1234AF", "Standard", "CSR", true, LocalDate.of(2018, Month.JUNE, 6)));
     }

--- a/src/test/resources/features/booking_details.feature
+++ b/src/test/resources/features/booking_details.feature
@@ -144,9 +144,8 @@ Feature: Booking Details
     When an offender booking assessment information POST request is made with offender numbers "" and "CSR"
     Then bad request response is received from booking assessments API with message "List of Offender Ids must be provided"
 
-  @broken
   Scenario: Request for CSRAs for multiple offenders (using post request which allows large sets of offenders)
-    When an offender booking CSRA information POST request is made with offender numbers "A1234AA,A1234AB,A1234AC,A1234AD,A1234AE,A1234AF,A1234AG,A1234AP,NEXIST"
+    When an offender booking CSRA information POST request is made with offender numbers "A1234AA,A1234AB,A1234AC,A1234AE,A1234AF,A1234AG,A1234AP,NEXIST"
     Then correct results are returned as for single assessment
 
   Scenario: Request for offenders who need to be categorised

--- a/src/test/resources/features/booking_details.feature
+++ b/src/test/resources/features/booking_details.feature
@@ -129,7 +129,7 @@ Feature: Booking Details
     Then resource not found response is received from booking assessments API
 
   Scenario: Request for CSR assessment information for multiple offenders
-    When an offender booking assessment information request is made with offender numbers "A1234AA,A1234AB,A1234AC,A1234AD,A1234AE,A1234AF,A1234AG,A1234AP,NEXIST" and "CSR" and latest="false" and active="true"
+    When an offender booking assessment information request is made with offender numbers "A1234AA,A1234AB,A1234AC,A1234AE,A1234AF,A1234AG,A1234AP,NEXIST" and "CSR" and latest="false" and active="true"
     Then correct results are returned as for single assessment
 
   Scenario: Request for category assessment information for multiple offenders
@@ -137,7 +137,7 @@ Feature: Booking Details
     Then full category history is returned
 
   Scenario: Request for CSR assessment information for multiple offenders (using post request which allows large sets of offenders)
-    When an offender booking assessment information POST request is made with offender numbers "A1234AA,A1234AB,A1234AC,A1234AD,A1234AE,A1234AF,A1234AG,A1234AP,NEXIST" and "CSR"
+    When an offender booking assessment information POST request is made with offender numbers "A1234AA,A1234AB,A1234AC,A1234AE,A1234AF,A1234AG,A1234AP,NEXIST" and "CSR"
     Then correct results are returned as for single assessment
 
   Scenario: Request for assessment information with empty list of offenders (using post request which allows large sets of offenders)


### PR DESCRIPTION
data setup for the prisoner A1234AD has the following
* calc level - LOW
* review level - null
* override level - MED

The new rules state that this will no longer be selected first, as it either needs a review level, or calculated as long as override is not present.

Given this data may be used elsewhere its easier to simply exclude it from the test set, given its now invalid.  Also removed from the non CSRA test as this uses the same step definition data.  The other tests provide enough coverage for the non CSRA one.