### PR TITLE
Open offender adjudications to view adjudications role

### DIFF
--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceImplIntTest_getAdjudications.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceImplIntTest_getAdjudications.java
@@ -1,0 +1,47 @@
+package uk.gov.justice.hmpps.prison.api.resource.impl;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import uk.gov.justice.hmpps.prison.api.model.ErrorResponse;
+import uk.gov.justice.hmpps.prison.executablespecification.steps.AuthTokenHelper.AuthToken;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class OffenderResourceImplIntTest_getAdjudications extends ResourceTest {
+
+    @Test
+    public void shouldReturnListOfAdjudications() {
+        final var token = authTokenHelper.getToken(AuthToken.NORMAL_USER);
+
+        final var request = createHttpEntity(token, null);
+
+        final var response = testRestTemplate.exchange(
+            "/api/offenders/A1234AA/adjudications",
+            HttpMethod.GET,
+            request,
+            new ParameterizedTypeReference<String>() {
+            });
+
+        final var json = getBodyAsJsonContent(response);
+
+        Assertions.assertThat(json).extractingJsonPathArrayValue("results").hasSizeGreaterThan(0);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldReturn404WhenNoPrivileges() {
+        // run with user that doesn't have access to the caseload
+        final var requestEntity = createHttpEntityWithBearerAuthorisation("ITAG_USER_ADM", List.of(), Map.of());
+
+        final var response = testRestTemplate.exchange(
+            "/api/offenders/A1234AA/adjudications", HttpMethod.GET, requestEntity, ErrorResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceImplIntTest_getAdjudications.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceImplIntTest_getAdjudications.java
@@ -44,4 +44,14 @@ public class OffenderResourceImplIntTest_getAdjudications extends ResourceTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
+
+    @Test
+    public void returns404ForViewAdjudicationsRole() {
+        final var requestEntity = createHttpEntityWithBearerAuthorisation("ROLE_VIEW_ADJUDICATIONS", List.of(), Map.of());
+
+        final var response = testRestTemplate.exchange(
+            "/api/offenders/A1234AA/adjudications", HttpMethod.GET, requestEntity, ErrorResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
 }


### PR DESCRIPTION
At present the `VIEW_ADJUDICATIONS` role does not grant access to adjudications via: 

`GET https://api-preprod.prison.service.justice.gov.uk/api/offenders/{NOMS}/adjudications]`

It returns a `404` unless a NOMIS username is provided when getting a token: 

`https://sign-in-dev.hmpps.service.justice.gov.uk/auth/oauth/token?username=MY-NOMIS-USERNAME`

generating a JWT like:

```json
{
    "sub": "NOMIS-USERNAME",
    "grant_type": "client_credentials",
    "user_name": "NOMIS-USERNAME",
    "scope": [
        "read"
    ],
    "auth_source": "none",
    "iss": "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/issuer",
    "exp": 1663777293,
    "authorities": [
        ...
        "ROLE_VIEW_PRISONER_DATA",
        "ROLE_VIEW_ADJUDICATIONS"
    ],
    "jti": "XXX",
    "client_id": "my-name"
}
```

Andy Marke has suggested a patch to `OffenderResource` which I include, which is adding the annotation:

```java
@VerifyOffenderAccess(overrideRoles = {"SYSTEM_USER","VIEW_ADJUDICATIONS", "VIEW_PRISONER_DATA"})`)
```

I could do with some help writing the appropriate tests around this fix -- as I'm not a Java developer this is probably not a great use of my time!