### PR TITLE
SDI-266 Transfer by TAP should copy address/city to new movement

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/ExternalMovement.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/ExternalMovement.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.JoinColumnsOrFormulas;
 import org.hibernate.annotations.JoinFormula;
 import org.hibernate.annotations.Type;
 
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
@@ -134,6 +135,7 @@ public class ExternalMovement extends AuditableEntity {
     private Long toAddressId;
 
     @Column(name = "FROM_ADDRESS_ID")
+    @Nullable
     private Long fromAddressId;
 
     public String calculateReleaseLocationDescription() {

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/ExternalMovementTransferService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/ExternalMovementTransferService.kt
@@ -215,12 +215,12 @@ class ExternalMovementTransferService(
           /* escortText = */ null,
           /* commentText = */ commentText,
           /* toCity = */ null,
-          /* fromCity = */ lastMovement.toCity,
+          /* fromCity = */ null,
           /* movementReason = */ movementReason,
           /* movementDirection = */ MovementDirection.IN,
           /* movementType = */ movementType,
           /* toAddressId = */ null,
-          /* fromAddressId = */ lastMovement.toAddressId,
+          /* fromAddressId = */ null,
         )
       )
     }

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTransferImpTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTransferImpTest.kt
@@ -1623,10 +1623,10 @@ class OffendersResourceTransferImpTest : ResourceTest() {
           }
 
           @Test
-          internal fun `from city should be taken from the city transferred to`() {
+          internal fun `from city will not be set since it is a transfer`() {
             temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "MDI"))
 
-            assertThat(dataLoaderTransaction.get { lastMovement(bookingId).fromCity?.code }).isEqualTo(toCityId)
+            assertThat(dataLoaderTransaction.get { lastMovement(bookingId).fromCity }).isNull()
           }
 
           @Test
@@ -1820,7 +1820,7 @@ class OffendersResourceTransferImpTest : ResourceTest() {
 
       @Nested
       @DisplayName("With a scheduled temporary absence")
-      open inner class WithScheduledTAP {
+      inner class WithScheduledTAP {
         private var scheduledEventId: Long = 0
         private var addressId: Long = -22
 
@@ -1843,23 +1843,60 @@ class OffendersResourceTransferImpTest : ResourceTest() {
           )
         }
 
-        @Test
-        internal fun `will complete scheduled movement event`() {
-          assertThat(testDataContext.getScheduledMovements(bookingId)).extracting("eventStatus.code")
-            .containsExactly("COMP", "SCH")
+        @Nested
+        inner class SamePrison {
+          @Test
+          internal fun `will complete scheduled movement event`() {
+            assertThat(testDataContext.getScheduledMovements(bookingId)).extracting("eventStatus.code")
+              .containsExactly("COMP", "SCH")
 
-          temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "LEI"))
+            temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "LEI"))
 
-          val scheduledTAPEvents = testDataContext.getScheduledMovements(bookingId)
-          assertThat(scheduledTAPEvents).extracting("eventStatus.code").containsExactly("COMP", "COMP")
-          assertThat(testDataContext.getMovements(bookingId).last().eventId).isEqualTo(scheduledTAPEvents.last().id)
+            val scheduledTAPEvents = testDataContext.getScheduledMovements(bookingId)
+            assertThat(scheduledTAPEvents).extracting("eventStatus.code").containsExactly("COMP", "COMP")
+            assertThat(testDataContext.getMovements(bookingId).last().eventId).isEqualTo(scheduledTAPEvents.last().id)
+          }
+
+          @Test
+          internal fun `from addressId should taken from to OUT addressId`() {
+            temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "LEI"))
+
+            assertThat(lastMovement(bookingId).fromAddressId).isEqualTo(addressId)
+          }
+
+          @Test
+          internal fun `from from agency will not be set`() {
+            temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "LEI"))
+
+            assertThat(dataLoaderTransaction.get { lastMovement(bookingId).fromAgency }).isNull()
+          }
         }
+        @Nested
+        inner class DifferentPrison {
+          @Test
+          internal fun `will not complete scheduled movement event`() {
+            assertThat(testDataContext.getScheduledMovements(bookingId)).extracting("eventStatus.code")
+              .containsExactly("COMP", "SCH")
 
-        @Test
-        internal fun `from addressId should taken from to OUT addressId`() {
-          temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "LEI"))
+            temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "MDI"))
 
-          assertThat(lastMovement(bookingId).fromAddressId).isEqualTo(addressId)
+            val scheduledTAPEvents = testDataContext.getScheduledMovements(bookingId)
+            assertThat(scheduledTAPEvents).extracting("eventStatus.code").containsExactly("COMP", "SCH")
+          }
+
+          @Test
+          internal fun `from addressId will not be populated since this is a transfer`() {
+            temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "MDI"))
+
+            assertThat(lastMovement(bookingId).fromAddressId).isNull()
+          }
+
+          @Test
+          internal fun `from from agency will taken from OUT movement`() {
+            temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "MDI"))
+
+            assertThat(dataLoaderTransaction.get { lastMovement(bookingId).fromAgency.id }).isEqualTo("LEI")
+          }
         }
       }
 

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTransferImpTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffendersResourceTransferImpTest.kt
@@ -1858,14 +1858,14 @@ class OffendersResourceTransferImpTest : ResourceTest() {
           }
 
           @Test
-          internal fun `from addressId should taken from to OUT addressId`() {
+          internal fun `from addressId should taken from the OUT addressId`() {
             temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "LEI"))
 
             assertThat(lastMovement(bookingId).fromAddressId).isEqualTo(addressId)
           }
 
           @Test
-          internal fun `from from agency will not be set`() {
+          internal fun `from agency will not be set`() {
             temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "LEI"))
 
             assertThat(dataLoaderTransaction.get { lastMovement(bookingId).fromAgency }).isNull()
@@ -1892,7 +1892,7 @@ class OffendersResourceTransferImpTest : ResourceTest() {
           }
 
           @Test
-          internal fun `from from agency will taken from OUT movement`() {
+          internal fun `from agency will be taken from OUT movement`() {
             temporaryAbsenceArrival(temporaryAbsenceArrivalRequest(agencyId = "MDI"))
 
             assertThat(dataLoaderTransaction.get { lastMovement(bookingId).fromAgency.id }).isEqualTo("LEI")

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/ExternalMovementTransferServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/ExternalMovementTransferServiceTest.kt
@@ -744,7 +744,7 @@ internal class ExternalMovementTransferServiceTest {
       }
 
       @Test
-      internal fun `new movement should specify the movement from TAP visited place to prison`() {
+      internal fun `new movement should only specify the prison they originated from`() {
         val movement =
           service.updateMovementsForTransferInAfterTemporaryAbsenceToDifferentPrison(
             movementDateTime = dateTime,
@@ -754,9 +754,8 @@ internal class ExternalMovementTransferServiceTest {
             commentText = commentText,
           )
         assertThat(movement.toAgency).isEqualTo(toPrison)
-        assertThat(movement.fromAddressId).isEqualTo(bookingLastMovementForTAP.toAddressId)
-        // in reality either addressId or City would be set but for this test the last movement has both set
-        assertThat(movement.fromCity).isEqualTo(bookingLastMovementForTAP.toCity)
+        assertThat(movement.fromAddressId).isNull()
+        assertThat(movement.fromCity).isNull()
       }
 
       @Test


### PR DESCRIPTION
Minor defect fix; the TAP out movement location (city or address) was incorrectly being copied to IN movement when returning to a different prison; NOMIS does not do this, it only does it returning to same prison