### PR TITLE
NN-4598 amend hearing endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OicHearingResponse.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OicHearingResponse.java
@@ -18,9 +18,9 @@ import java.time.LocalDateTime;
 @Builder(toBuilder = true)
 public class OicHearingResponse {
 
-    @Schema(required = true, description = "nomis hearing id")
+    @Schema(required = true, description = "nomis oic hearing id")
     @NotNull
-    private Long hearingId;
+    private Long oicHearingId;
 
     @Schema(required = true, description = "When the hearing is scheduled for", example = "15-06-2020T09:03:11")
     @NotNull

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
@@ -142,19 +142,38 @@ public class AdjudicationsResource {
     }
 
     @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Oic Hearing updated"),
+        @ApiResponse(responseCode = "403", description = "The client is not authorised for this operation"),
+        @ApiResponse(responseCode = "400", description = "Invalid request - ie missing hearing location or date, or the hearing does not belong to the adjudication", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "404", description = "No match was found for the adjudication number", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "Amends an OIC hearing", description = "Requires MAINTAIN_ADJUDICATIONS access and write scope")
+    @PutMapping("/adjudication/{adjudicationNumber}/hearing/{oicHearingId}")
+    @ProxyUser
+    @PreAuthorize("hasRole('MAINTAIN_ADJUDICATIONS') and hasAuthority('SCOPE_write')")
+    @ResponseStatus(HttpStatus.OK)
+    public void amendOicHearing(
+        @Valid @RequestBody @Parameter(description = "OIC hearing to amend", required = true) final OicHearingRequest oicHearingRequest,
+        @PathVariable("adjudicationNumber") final Long adjudicationNumber,
+        @PathVariable("oicHearingId") final Long oicHearingId
+    ) {
+        adjudicationsService.amendOicHearing(adjudicationNumber, oicHearingId, oicHearingRequest);
+    }
+
+    @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Hearing was deleted"),
         @ApiResponse(responseCode = "403", description = "The client is not authorised for this operation"),
         @ApiResponse(responseCode = "400", description = "Invalid request - the hearing does not belong to the adjudication", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "404", description = "No match was found for the adjudication number or hearing id", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
     @Operation(summary = "deletes an OIC hearing", description = "Requires MAINTAIN_ADJUDICATIONS access and write scope")
-    @DeleteMapping("/adjudication/{adjudicationNumber}/hearing/{hearingId}")
+    @DeleteMapping("/adjudication/{adjudicationNumber}/hearing/{oicHearingId}")
     @ProxyUser
     @PreAuthorize("hasRole('MAINTAIN_ADJUDICATIONS') and hasAuthority('SCOPE_write')")
     public void deleteOicHearing(
         @PathVariable("adjudicationNumber") final Long adjudicationNumber,
-        @PathVariable("hearingId") final Long hearingId
+        @PathVariable("oicHearingId") final Long oicHearingId
     ) {
-        adjudicationsService.deleteOicHearing(adjudicationNumber, hearingId);
+        adjudicationsService.deleteOicHearing(adjudicationNumber, oicHearingId);
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
@@ -258,6 +258,9 @@ public class AdjudicationsService {
     @Transactional
     @VerifyOffenderAccess
     public OicHearingResponse createOicHearing(final Long adjudicationNumber, final OicHearingRequest oicHearingRequest) {
+        adjudicationsRepository.findByParties_AdjudicationNumber(adjudicationNumber)
+            .orElseThrow(EntityNotFoundException.withMessage(format("Could not find adjudication number %d", adjudicationNumber)));
+
         oicHearingLocationValidation(oicHearingRequest.getHearingLocationId());
 
         final var hearingDate = oicHearingRequest.getDateTimeOfHearing().toLocalDate();

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
@@ -258,9 +258,6 @@ public class AdjudicationsService {
     @Transactional
     @VerifyOffenderAccess
     public OicHearingResponse createOicHearing(final Long adjudicationNumber, final OicHearingRequest oicHearingRequest) {
-        adjudicationsRepository.findByParties_AdjudicationNumber(adjudicationNumber)
-            .orElseThrow(EntityNotFoundException.withMessage(format("Could not find adjudication number %d", adjudicationNumber)));
-
         oicHearingLocationValidation(oicHearingRequest.getHearingLocationId());
 
         final var hearingDate = oicHearingRequest.getDateTimeOfHearing().toLocalDate();

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/AdjudicationsResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/AdjudicationsResourceTest.java
@@ -478,6 +478,83 @@ public class AdjudicationsResourceTest extends ResourceTest  {
         }
 
         @Test
+        public void amendHearingReturns403ForInvalidRoles () {
+            webTestClient.put()
+                .uri("/api/adjudications/adjudication/-9/hearing/-4")
+                .headers(setAuthorisation(invalid))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(validRequest)
+                .exchange()
+                .expectStatus().isForbidden();
+        }
+        @Test
+        public void amendHearingReturns404DueToNoAdjudication() {
+            webTestClient.put()
+                .uri( "/api/adjudications/adjudication/99/hearing/-4")
+                .headers(setAuthorisation(valid))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(validRequest)
+                .exchange()
+                .expectStatus().isNotFound();
+        }
+
+        @Test
+        public void amendHearingReturns400() {
+            webTestClient.put()
+                .uri("/api/adjudications/adjudication/-9/hearing/-4")
+                .headers(setAuthorisation(valid))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(invalidRequest)
+                .exchange()
+                .expectStatus().isBadRequest();
+        }
+
+        @Test
+        public void amendHearingReturns400forOicHearingType() {
+            webTestClient.put()
+                .uri("/api/adjudications/adjudication/-9/hearing/-4")
+                .headers(setAuthorisation(valid))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(invalidTypeRequest)
+                .exchange()
+                .expectStatus().isBadRequest();
+        }
+
+        @Test
+        public void amendHearingReturns400forLocationId() {
+            webTestClient.put()
+                .uri("/api/adjudications/adjudication/-9/hearing/-4")
+                .headers(setAuthorisation(valid))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(invalidLocationRequest)
+                .exchange()
+                .expectStatus().isBadRequest();
+        }
+
+        @Test
+        public void amendHearingInvalidRequestAsHearingDoesNotBelongToAdjudication() {
+            webTestClient.put()
+                .uri("/api/adjudications/adjudication/-5/hearing/-4")
+                .headers(setAuthorisation(valid))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(validRequest)
+                .exchange()
+                .expectStatus().isBadRequest();
+        }
+
+        @Test
+        public void amendHearing() {
+            webTestClient.put()
+                .uri("/api/adjudications/adjudication/-9/hearing/-4")
+                .headers(setAuthorisation(valid))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(validRequest)
+                .exchange()
+                .expectStatus().isOk();
+        }
+
+
+        @Test
         public void deleteHearingReturns403DueToInvalidRoles () {
             webTestClient.delete()
                 .uri("/api/adjudications/adjudication/-9/hearing/1")

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
@@ -925,6 +925,23 @@ public class AdjudicationsServiceTest {
         }
 
         @Test
+        public void amendHearingHearingNotFound () {
+            when(adjudicationsRepository.findByParties_AdjudicationNumber(1L))
+                .thenReturn(Optional.of(
+                    Adjudication.builder().build()
+                ));
+
+            when(oicHearingRepository.findById(2L)).thenReturn(
+                Optional.empty()
+            );
+
+            assertThatThrownBy(() ->
+                service.amendOicHearing(1L, 2L, oicHearingRequest))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Could not find oic hearingId 2 for adjudication number 1");
+        }
+
+        @Test
         public void amendHearingInvalidLocationId () {
             when(adjudicationsRepository.findByParties_AdjudicationNumber(1L))
                 .thenReturn(Optional.of(


### PR DESCRIPTION
new amend endpoint to simplify the adjudications api when editing a hearing.  Originally it was assumed nomis would only allow a delete / create however this is not the case as its a new set of apis.