### PR TITLE
SDI-433 Tidy NOMIS context for write connections

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
@@ -43,7 +43,7 @@ public class OracleConnectionAspect extends AbstractConnectionAspect {
     @Override
     protected Connection openProxySessionIfIdentifiedAuthentication(final Connection pooledConnection) throws SQLException {
         if (!RoutingDataSource.isReplica()) {
-            clearContext((pooledConnection));
+            clearContext(pooledConnection);
         }
         if (proxyUserEndpointAndUserSignedIntoNomis()) {
             log.trace("Configuring Oracle Proxy Session for NOMIS user {}", pooledConnection);

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
@@ -13,11 +13,13 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import static java.lang.String.format;
+import static uk.gov.justice.hmpps.prison.aop.connectionproxy.AppModuleName.MERGE;
+import static uk.gov.justice.hmpps.prison.aop.connectionproxy.AppModuleName.PRISON_API;
 import static uk.gov.justice.hmpps.prison.security.AuthSource.NOMIS;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.IP_ADDRESS;
-import static uk.gov.justice.hmpps.prison.util.MdcUtility.NOMIS_CONTEXT;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.PROXY_USER;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.REQUEST_URI;
+import static uk.gov.justice.hmpps.prison.util.MdcUtility.SUPPRESS_XTAG_EVENTS;
 import static uk.gov.justice.hmpps.prison.util.MdcUtility.USER_ID_HEADER;
 
 @Aspect
@@ -40,12 +42,12 @@ public class OracleConnectionAspect extends AbstractConnectionAspect {
 
     @Override
     protected Connection openProxySessionIfIdentifiedAuthentication(final Connection pooledConnection) throws SQLException {
-        final var proxyUserAuthSource = authenticationFacade.getProxyUserAuthenticationSource();
-        if (proxyUserAuthSource == NOMIS) {
+        if (proxyUserEndpointAndUserSignedIntoNomis()) {
             log.trace("Configuring Oracle Proxy Session for NOMIS user {}", pooledConnection);
             assertNotSlow();
             return openAndConfigureProxySessionForConnection(pooledConnection);
-        } else if (StringUtils.isNotBlank(MDC.get(PROXY_USER))) {
+        }
+        else if (proxyUserEndpointAndUserIncludedInClientCredentials()) {
             assertNotSlow();
             // If proxy user is set - try to set the context - allow it to fail and carry on
             try {
@@ -54,9 +56,21 @@ public class OracleConnectionAspect extends AbstractConnectionAspect {
                 log.warn("Failed to set context for proxy user {}", MDC.get(PROXY_USER));
             }
         }
+        else if ("true".equals(MDC.get(SUPPRESS_XTAG_EVENTS))) {
+            setContextAuditModuleOnly(pooledConnection);
+        }
 
         setDefaultSchema(pooledConnection);
         return pooledConnection;
+    }
+
+    private boolean proxyUserEndpointAndUserSignedIntoNomis() {
+        final var proxyUserAuthSource = authenticationFacade.getProxyUserAuthenticationSource();
+        return proxyUserAuthSource == NOMIS;
+    }
+
+    private boolean proxyUserEndpointAndUserIncludedInClientCredentials() {
+        return StringUtils.isNotBlank(MDC.get(PROXY_USER));
     }
 
     private void assertNotSlow() {
@@ -113,15 +127,35 @@ public class OracleConnectionAspect extends AbstractConnectionAspect {
     private void setContext(final Connection conn) throws SQLException {
         final var sql = format("""
                 BEGIN
-                nomis_context.set_context('AUDIT_MODULE_NAME','%s');
+                %s;
                 nomis_context.set_context('AUDIT_USER_ID', '%s');
                 nomis_context.set_client_nomis_context('%s', '%s', '%s', '%s');
                 END;""",
-            MDC.get(NOMIS_CONTEXT),
+            callAuditModuleText(),
             MDC.get(USER_ID_HEADER),
             MDC.get(USER_ID_HEADER), MDC.get(IP_ADDRESS), "API", MDC.get(REQUEST_URI));
         try (final var ps = conn.prepareStatement(sql)) {
             ps.execute();
         }
     }
+
+    private void setContextAuditModuleOnly(final Connection conn) throws SQLException {
+        final var sql = format("""
+                BEGIN
+                %s;
+                END;""",
+            callAuditModuleText());
+        try (final var ps = conn.prepareStatement(sql)) {
+            ps.execute();
+        }
+    }
+
+    private String callAuditModuleText() {
+        var nomisContext = PRISON_API;
+        if ("true".equals(MDC.get(SUPPRESS_XTAG_EVENTS))) {
+            nomisContext = MERGE;
+        }
+        return format("nomis_context.set_context('AUDIT_MODULE_NAME', '%s')", nomisContext);
+    }
+
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AppointmentsResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AppointmentsResource.java
@@ -57,6 +57,7 @@ public class AppointmentsResource {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{appointmentId}")
     @HasWriteScope
+    @ProxyUser
     public void deleteAppointment(
         @PathVariable("appointmentId")
         @Parameter(description = "The unique identifier for the appointment", required = true)
@@ -73,6 +74,7 @@ public class AppointmentsResource {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/delete")
     @HasWriteScope
+    @ProxyUser
     public void deleteAppointments(
         @Parameter(description = "The unique identifier for the appointment", required = true)
         @NotNull @RequestBody List<Long> appointmentIds

--- a/src/main/java/uk/gov/justice/hmpps/prison/util/MdcUtility.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/util/MdcUtility.java
@@ -13,7 +13,7 @@ public class MdcUtility {
     public static final String PROXY_USER = "proxy-user";
     public static final String IP_ADDRESS = "clientIpAddress";
     public static final String REQUEST_URI = "request-url";
-    public static final String NOMIS_CONTEXT = "nomis-context";
+    public static final String SUPPRESS_XTAG_EVENTS = "suppress-xtag-events";
 
     public static boolean isLoggingAllowed() {
         return !"true".equals(MDC.get(SKIP_LOGGING));

--- a/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.java
@@ -77,9 +77,10 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
-                assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_client_nomis_context");
+                verify(pooledConnection, times(3)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                assertThat(sqlCaptor.getAllValues().get(2)).contains("nomis_context.set_client_nomis_context");
             }
 
         }
@@ -102,9 +103,10 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.set_client_nomis_context");
-                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                verify(pooledConnection, times(3)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_client_nomis_context");
+                assertThat(sqlCaptor.getAllValues().get(2)).contains("ALTER SESSION SET CURRENT_SCHEMA");
             }
         }
 
@@ -126,9 +128,10 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(1)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).doesNotContain("nomis_context.set_context('AUDIT_MODULE_NAME'");
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
+                assertThat(sqlCaptor.getAllValues().get(1)).doesNotContain("nomis_context.set_context('AUDIT_MODULE_NAME'");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
             }
 
             @Test
@@ -139,10 +142,11 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).doesNotContain("nomis_context.set_client_nomis_context");
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.set_context('AUDIT_MODULE_NAME', 'MERGE')");
-                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                verify(pooledConnection, times(3)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
+                assertThat(sqlCaptor.getAllValues().get(1)).doesNotContain("nomis_context.set_client_nomis_context");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_context('AUDIT_MODULE_NAME', 'MERGE')");
+                assertThat(sqlCaptor.getAllValues().get(2)).contains("ALTER SESSION SET CURRENT_SCHEMA");
             }
         }
     }

--- a/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.java
@@ -1,8 +1,13 @@
 package uk.gov.justice.hmpps.prison.aop.connectionproxy;
 
 import oracle.jdbc.driver.OracleConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.slf4j.MDC;
 import uk.gov.justice.hmpps.prison.security.AuthSource;
 import uk.gov.justice.hmpps.prison.security.AuthenticationFacade;
 
@@ -16,10 +21,13 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.hmpps.prison.util.MdcUtility.PROXY_USER;
+import static uk.gov.justice.hmpps.prison.util.MdcUtility.SUPPRESS_XTAG_EVENTS;
 
 class OracleConnectionAspectTest {
 
@@ -33,56 +41,119 @@ class OracleConnectionAspectTest {
 
     private final OracleConnectionAspect connectionAspect = new OracleConnectionAspect(authenticationFacade, roleConfigurer, defaultSchema);
 
-    @Test
-    void openProxySessionIfIdentifiedAuthentication_nomisUser_opensProxyConnection() throws SQLException {
-        configureMocks(AuthSource.NOMIS);
+    private MockedStatic<MDC> mockMdc;
 
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
-
-        ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
-        verify(proxyConnection).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), propertiesCaptor.capture());
-        assertThat(propertiesCaptor.getValue().get((OracleConnection.PROXY_USER_NAME))).isEqualTo("some user name");
+    @BeforeEach
+    void init() {
+        mockMdc = mockStatic(MDC.class);
     }
 
-    @Test
-    void openProxySessionIfIdentifiedAuthentication_nomisUser_setSchemaAndContext() throws SQLException {
-        configureMocks(AuthSource.NOMIS);
-
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
-
-        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
-        assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
-        assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_context");
+    @AfterEach
+    void close() {
+        mockMdc.close();
     }
 
-    @Test
-    void openProxySessionIfIdentifiedAuthentication_notANomisUser_doesntOpenProxyConnection() throws SQLException {
-        configureMocks(AuthSource.NONE);
+    @Nested
+    class OpenProxySessionIfIdentifiedAuthentication {
 
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+        @Nested
+        class NomisUser {
 
-        verify(proxyConnection, never()).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), any(Properties.class));
+            @Test
+            void opensProxyConnection() throws SQLException {
+                configureMocks(AuthSource.NOMIS, "");
+
+                connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+                ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
+                verify(proxyConnection).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), propertiesCaptor.capture());
+                assertThat(propertiesCaptor.getValue().get((OracleConnection.PROXY_USER_NAME))).isEqualTo("some user name");
+            }
+
+            @Test
+            void setSchemaAndContext() throws SQLException {
+                configureMocks(AuthSource.NOMIS, "");
+
+                connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+                ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_client_nomis_context");
+            }
+
+        }
+
+        @Nested
+        class ProxyUser {
+            @Test
+            void doesntOpenProxyConnection() throws SQLException {
+                configureMocks(AuthSource.NONE, "some_user");
+
+                connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+                verify(proxyConnection, never()).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), any(Properties.class));
+            }
+
+            @Test
+            void setSchemaAndContext() throws SQLException {
+                configureMocks(AuthSource.NONE, "some_user");
+
+                connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+                ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.set_client_nomis_context");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+            }
+        }
+
+        @Nested
+        class NotNomisOrProxyUser {
+            @Test
+            void doesntOpenProxyConnection() throws SQLException {
+                configureMocks(AuthSource.NONE, "");
+
+                connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+                verify(proxyConnection, never()).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), any(Properties.class));
+            }
+
+            @Test
+            void dontSuppressEvents_thenDontSetContextAuditModule() throws SQLException {
+                configureMocks(AuthSource.NONE, "");
+
+                connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+                ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+                verify(pooledConnection, times(1)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).doesNotContain("nomis_context.set_context('AUDIT_MODULE_NAME'");
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+            }
+
+            @Test
+            void suppressEvents_thenSetContextAuditModuleToMerge() throws SQLException {
+                configureMocks(AuthSource.NONE, "");
+                when(MDC.get(SUPPRESS_XTAG_EVENTS)).thenReturn("true");
+
+                connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+                ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).doesNotContain("nomis_context.set_client_nomis_context");
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.set_context('AUDIT_MODULE_NAME', 'MERGE')");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+            }
+        }
     }
 
-    @Test
-    void openProxySessionIfIdentifiedAuthentication_notANomisUser_setSchemaButNotContext() throws SQLException {
-        configureMocks(AuthSource.NONE);
-
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
-
-        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(pooledConnection, times(1)).prepareStatement(sqlCaptor.capture());
-        assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
-    }
-
-    private void configureMocks(AuthSource authSource) throws SQLException {
+    private void configureMocks(AuthSource authSource, String proxyUser) throws SQLException {
         when(authenticationFacade.getProxyUserAuthenticationSource()).thenReturn(authSource);
         when(authenticationFacade.getCurrentUsername()).thenReturn("some user name");
         when(pooledConnection.unwrap(Connection.class)).thenReturn(proxyConnection);
         when(proxyConnection.prepareStatement(anyString())).thenReturn(proxyPreparedStatement);
         when(pooledConnection.prepareStatement(anyString())).thenReturn(pooledPreparedStatement);
-
+        when(MDC.get(PROXY_USER)).thenReturn(proxyUser);
+        when(MDC.get(SUPPRESS_XTAG_EVENTS)).thenReturn("false");
     }
-
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/web/filter/EventPropagationFilterTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/web/filter/EventPropagationFilterTest.kt
@@ -7,39 +7,37 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.slf4j.MDC
-import uk.gov.justice.hmpps.prison.aop.connectionproxy.AppModuleName.MERGE
-import uk.gov.justice.hmpps.prison.aop.connectionproxy.AppModuleName.PRISON_API
-import uk.gov.justice.hmpps.prison.util.MdcUtility.NOMIS_CONTEXT
+import uk.gov.justice.hmpps.prison.util.MdcUtility.SUPPRESS_XTAG_EVENTS
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class NomisContextFilterTest {
+class EventPropagationFilterTest {
 
   private val request = mock<HttpServletRequest>()
   private val response = mock<HttpServletResponse>()
   private val filterChain = mock<FilterChain>()
-  private val filter = NomisContextFilter()
+  private val filter = EventPropagationFilter()
 
   @Test
-  fun shouldUsePrisonApiContext() {
+  fun shouldNotSuppressEvents() {
     mockStatic(MDC::class.java).use { mockMdc ->
       filter.doFilter(request, response, filterChain)
 
-      mockMdc.verify { MDC.put(NOMIS_CONTEXT, PRISON_API.name) }
+      mockMdc.verify { MDC.put(SUPPRESS_XTAG_EVENTS, "false") }
       verify(request).getHeader("no-event-propagation")
       verify(filterChain).doFilter(request, response)
     }
   }
 
   @Test
-  fun shouldUseMergeContext() {
+  fun shouldSuppressEvents() {
     mockStatic(MDC::class.java).use { mockMdc ->
       whenever(request.getHeader(anyString())).thenReturn("true")
 
       filter.doFilter(request, response, filterChain)
 
-      mockMdc.verify { MDC.put(NOMIS_CONTEXT, MERGE.name) }
+      mockMdc.verify { MDC.put(SUPPRESS_XTAG_EVENTS, "true") }
       verify(request).getHeader("no-event-propagation")
       verify(filterChain).doFilter(request, response)
     }


### PR DESCRIPTION
Currently the NOMIS context can leak between connections. This has an impact on the suppression of XTag events where the NOMIS MERGE context was not applied for some connections, or was left in place for others - both incorrectly.
This PR should clear the NOMIS context whenever a connection to the primary database is acquired and makes sure the MERGE context is used where attempting to suppress XTag events.