### PR TITLE
SDI-429 Don't clear the session - it's then broken forever

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
@@ -65,12 +65,6 @@ public class OracleConnectionAspect extends AbstractConnectionAspect {
         return pooledConnection;
     }
 
-    private void clearContext(Connection conn) throws SQLException {
-        try (final var ps = conn.prepareStatement("BEGIN nomis_context.close_session(); END;")) {
-            ps.execute();
-        }
-    }
-
     private boolean proxyUserEndpointAndUserSignedIntoNomis() {
         final var proxyUserAuthSource = authenticationFacade.getProxyUserAuthenticationSource();
         return proxyUserAuthSource == NOMIS;

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.java
@@ -42,9 +42,6 @@ public class OracleConnectionAspect extends AbstractConnectionAspect {
 
     @Override
     protected Connection openProxySessionIfIdentifiedAuthentication(final Connection pooledConnection) throws SQLException {
-        if (!RoutingDataSource.isReplica()) {
-            clearContext(pooledConnection);
-        }
         if (proxyUserEndpointAndUserSignedIntoNomis()) {
             log.trace("Configuring Oracle Proxy Session for NOMIS user {}", pooledConnection);
             assertNotSlow();

--- a/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.java
@@ -77,10 +77,9 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(3)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
-                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
-                assertThat(sqlCaptor.getAllValues().get(2)).contains("nomis_context.set_client_nomis_context");
+                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_client_nomis_context");
             }
 
         }
@@ -103,10 +102,9 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(3)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
-                assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_client_nomis_context");
-                assertThat(sqlCaptor.getAllValues().get(2)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.set_client_nomis_context");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
             }
         }
 
@@ -128,10 +126,9 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
-                assertThat(sqlCaptor.getAllValues().get(1)).doesNotContain("nomis_context.set_context('AUDIT_MODULE_NAME'");
-                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                verify(pooledConnection, times(1)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).doesNotContain("nomis_context.set_context('AUDIT_MODULE_NAME'");
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
             }
 
             @Test
@@ -142,11 +139,10 @@ class OracleConnectionAspectTest {
                 connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
 
                 ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-                verify(pooledConnection, times(3)).prepareStatement(sqlCaptor.capture());
-                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.close_session()");
-                assertThat(sqlCaptor.getAllValues().get(1)).doesNotContain("nomis_context.set_client_nomis_context");
-                assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_context('AUDIT_MODULE_NAME', 'MERGE')");
-                assertThat(sqlCaptor.getAllValues().get(2)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+                verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+                assertThat(sqlCaptor.getAllValues().get(0)).doesNotContain("nomis_context.set_client_nomis_context");
+                assertThat(sqlCaptor.getAllValues().get(0)).contains("nomis_context.set_context('AUDIT_MODULE_NAME', 'MERGE')");
+                assertThat(sqlCaptor.getAllValues().get(1)).contains("ALTER SESSION SET CURRENT_SCHEMA");
             }
         }
     }


### PR DESCRIPTION
We think we've found a bug where clearing the session when closing a Proxy connection then breaks the session context thereafter. Any further calls to set_context don't work.

This needs fixing properly but in the meantime remove the clear session recently added to all update connections which can only make things worse.