### PR TITLE
SDI-464 Tidy up logging around NOMIS connections

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/ProxyUserAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/ProxyUserAspect.java
@@ -33,7 +33,7 @@ public class ProxyUserAspect {
         var proxyUser = authenticationFacade.getCurrentUsername();
         try {
             if (proxyUser != null) {
-                log.debug("Proxying User: {} for {}->{}", proxyUser,
+                log.info("Proxying User: {} for {}->{}", proxyUser,
                         joinPoint.getSignature().getDeclaringTypeName(),
                         joinPoint.getSignature().getName());
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/AbstractConnectionAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/AbstractConnectionAspect.java
@@ -25,7 +25,7 @@ public abstract class AbstractConnectionAspect {
         }
         final var pooledConnection = (Connection) joinPoint.proceed();
         try {
-            final var connectionToReturn = openProxySessionIfIdentifiedAuthentication(pooledConnection);
+            final var connectionToReturn = configureNomisConnection(pooledConnection);
 
             if (log.isTraceEnabled() && MdcUtility.isLoggingAllowed()) {
                 log.trace(
@@ -50,5 +50,5 @@ public abstract class AbstractConnectionAspect {
         }
     }
 
-    protected abstract Connection openProxySessionIfIdentifiedAuthentication(final Connection pooledConnection) throws SQLException;
+    protected abstract Connection configureNomisConnection(final Connection pooledConnection) throws SQLException;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/HsqlConnectionAspect.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/HsqlConnectionAspect.java
@@ -22,7 +22,7 @@ public class HsqlConnectionAspect extends AbstractConnectionAspect {
     }
 
     @Override
-    protected Connection openProxySessionIfIdentifiedAuthentication(final Connection pooledConnection) throws SQLException {
+    protected Connection configureNomisConnection(final Connection pooledConnection) throws SQLException {
         final var userAuthSource = authenticationFacade.getAuthenticationSource();
         final var proxyUser = MDC.get(PROXY_USER);
         if (userAuthSource == NOMIS && !proxyUser.isBlank()) {

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/NomisConfigurer.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/NomisConfigurer.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.hmpps.prison.aop.connectionproxy
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.hmpps.prison.aop.connectionproxy.AppModuleName.MERGE
@@ -34,7 +33,6 @@ class NomisConfigurer(@Value("\${oracle.default.schema}") private val defaultSch
       END;
     """
       .trimIndent()
-      .also { sql -> log.info("Setting NOMIS context to: $sql") }
       .let { sql -> conn.run(sql) }
   }
 
@@ -46,7 +44,6 @@ class NomisConfigurer(@Value("\${oracle.default.schema}") private val defaultSch
       END;
     """
       .trimIndent()
-      .also { sql -> log.info("Setting NOMIS context to: $sql") }
       .let { sql -> conn.run(sql) }
   }
 
@@ -55,9 +52,5 @@ class NomisConfigurer(@Value("\${oracle.default.schema}") private val defaultSch
     if (defaultSchema.isNotBlank()) {
       conn.run("ALTER SESSION SET CURRENT_SCHEMA=$defaultSchema")
     }
-  }
-
-  companion object {
-    val log = LoggerFactory.getLogger(this::class.java)!!
   }
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspect.kt
@@ -28,7 +28,7 @@ class OracleConnectionAspect(
 ) : AbstractConnectionAspect() {
 
   @Throws(SQLException::class)
-  public override fun openProxySessionIfIdentifiedAuthentication(pooledConnection: Connection): Connection =
+  public override fun configureNomisConnection(pooledConnection: Connection): Connection =
     with(pooledConnection) {
       when {
         isNomisProxyUser() -> openProxySessionConnection()
@@ -40,7 +40,7 @@ class OracleConnectionAspect(
 
   @Throws(SQLException::class)
   private fun Connection.openProxySessionConnection(): Connection {
-    log.info("Configuring Oracle Proxy Session for NOMIS user {}", this)
+    log.info("Configuring Oracle Proxy Session")
     assertNotSlow()
     this.openProxySessionForCurrentUsername()
       .also { oracleConnection -> roleConfigurer.setRoleForConnection(oracleConnection) }
@@ -61,13 +61,12 @@ class OracleConnectionAspect(
     return (this.unwrap(Connection::class.java) as OracleConnection)
       .also { oracleConnection ->
         oracleConnection.openProxySession(OracleConnection.PROXYTYPE_USER_NAME, info)
-        log.debug("Proxy Connection for {} successful", currentUsername)
       }
   }
 
   @Throws(SQLException::class)
   private fun Connection.openResettableContextConnection(): Connection {
-    log.info("Configuring session for client credentials user {}", this)
+    log.info("Configuring session for client credentials user")
     assertNotSlow()
     return ResettableContextConnection(this)
       .also { connection ->
@@ -78,7 +77,7 @@ class OracleConnectionAspect(
 
   @Throws(SQLException::class)
   private fun Connection.openXtagsSuppressingConnection(): Connection {
-    log.info("Configuring session for no user suppressing XTag events {}", this)
+    log.info("Configuring session to suppress XTag events")
     assertNotSlow()
     return ResettableContextConnection(this)
       .also { connection ->

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/ProxySessionClosingConnection.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/ProxySessionClosingConnection.kt
@@ -9,7 +9,7 @@ class ProxySessionClosingConnection(private val connection: Connection) : Connec
 
   @Throws(SQLException::class)
   override fun close() {
-    log.debug("Closing proxy connection {}", this)
+    log.info("Closing proxy connection")
     (connection.unwrap(Connection::class.java) as OracleConnection)
       .also { oracleConnection ->
         closeSession(oracleConnection)

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/ResettableContextConnection.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/ResettableContextConnection.kt
@@ -8,7 +8,7 @@ class ResettableContextConnection(private val connection: Connection) : Connecti
 
   @Throws(SQLException::class)
   override fun close() {
-    log.debug("Closing context clearing connection {}", this)
+    log.debug("Closing resettable context connection")
     resetContext()
     connection.close()
   }

--- a/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/ResettableContextConnection.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/ResettableContextConnection.kt
@@ -8,7 +8,7 @@ class ResettableContextConnection(private val connection: Connection) : Connecti
 
   @Throws(SQLException::class)
   override fun close() {
-    log.debug("Closing resettable context connection")
+    log.info("Closing resettable context connection")
     resetContext()
     connection.close()
   }

--- a/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/aop/connectionproxy/OracleConnectionAspectTest.kt
@@ -66,7 +66,7 @@ class OracleConnectionAspectTest {
 
       @Test
       fun `should open proxy connection`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(oracleConnection).openProxySession(
           eq(OracleConnection.PROXYTYPE_USER_NAME),
@@ -78,14 +78,14 @@ class OracleConnectionAspectTest {
 
       @Test
       fun `should configure role`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(roleConfigurer).setRoleForConnection(oracleConnection)
       }
 
       @Test
       fun `should set Nomis context and schema`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(nomisConfigurer).setDefaultSchema(any<ProxySessionClosingConnection>())
         verify(nomisConfigurer).setNomisContext(any<ProxySessionClosingConnection>(), eq("some user name"), eq("some IP"), eq("some URI"), eq("APP"), eq(false))
@@ -95,14 +95,14 @@ class OracleConnectionAspectTest {
       fun `should suppress Xtag events`() {
         whenever(MDC.get(MdcUtility.SUPPRESS_XTAG_EVENTS)).thenReturn("true")
 
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(nomisConfigurer).setNomisContext(any<ProxySessionClosingConnection>(), eq("some user name"), eq("some IP"), eq("some URI"), eq("APP"), eq(true))
       }
 
       @Test
       fun `should return proxy connection`() {
-        val conn = connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        val conn = connectionAspect.configureNomisConnection(pooledConnection)
 
         assertThat(conn).isExactlyInstanceOf(ProxySessionClosingConnection::class.java)
       }
@@ -111,7 +111,7 @@ class OracleConnectionAspectTest {
       fun `should throw if replica`() {
         whenever(RoutingDataSource.isReplica()).thenReturn(true)
 
-        assertThatThrownBy { connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection) }
+        assertThatThrownBy { connectionAspect.configureNomisConnection(pooledConnection) }
           .isInstanceOf(RuntimeException::class.java)
       }
     }
@@ -125,21 +125,21 @@ class OracleConnectionAspectTest {
 
       @Test
       fun `should not open proxy connection`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(oracleConnection, never()).openProxySession(anyInt(), any())
       }
 
       @Test
       fun `should not configure role`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(roleConfigurer, never()).setRoleForConnection(any())
       }
 
       @Test
       fun `should set Nomis context and schema`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(nomisConfigurer).setDefaultSchema(any<ResettableContextConnection>())
         verify(nomisConfigurer).setNomisContext(any<ResettableContextConnection>(), eq("some user name"), eq("some IP"), eq("some URI"), eq("APP"), eq(false))
@@ -149,14 +149,14 @@ class OracleConnectionAspectTest {
       fun `should suppress Xtag events`() {
         whenever(MDC.get(MdcUtility.SUPPRESS_XTAG_EVENTS)).thenReturn("true")
 
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(nomisConfigurer).setNomisContext(any<ResettableContextConnection>(), eq("some user name"), eq("some IP"), eq("some URI"), eq("APP"), eq(true))
       }
 
       @Test
       fun `should return resettable context connection`() {
-        val conn = connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        val conn = connectionAspect.configureNomisConnection(pooledConnection)
 
         assertThat(conn).isExactlyInstanceOf(ResettableContextConnection::class.java)
       }
@@ -165,7 +165,7 @@ class OracleConnectionAspectTest {
       fun `should throw if replica`() {
         whenever(RoutingDataSource.isReplica()).thenReturn(true)
 
-        assertThatThrownBy { connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection) }
+        assertThatThrownBy { connectionAspect.configureNomisConnection(pooledConnection) }
           .isInstanceOf(RuntimeException::class.java)
       }
     }
@@ -180,21 +180,21 @@ class OracleConnectionAspectTest {
 
       @Test
       fun `should not open proxy connection`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(oracleConnection, never()).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), any())
       }
 
       @Test
       fun `should not configure role`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(roleConfigurer, never()).setRoleForConnection(any())
       }
 
       @Test
       fun `should set Nomis context and schema`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(nomisConfigurer).setSuppressXtagEvents(any<ResettableContextConnection>())
         verify(nomisConfigurer).setDefaultSchema(any<ResettableContextConnection>())
@@ -202,7 +202,7 @@ class OracleConnectionAspectTest {
 
       @Test
       fun `should return resettable context connection`() {
-        val conn = connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        val conn = connectionAspect.configureNomisConnection(pooledConnection)
 
         assertThat(conn).isExactlyInstanceOf(ResettableContextConnection::class.java)
       }
@@ -211,7 +211,7 @@ class OracleConnectionAspectTest {
       fun `should throw if replica`() {
         whenever(RoutingDataSource.isReplica()).thenReturn(true)
 
-        assertThatThrownBy { connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection) }
+        assertThatThrownBy { connectionAspect.configureNomisConnection(pooledConnection) }
           .isInstanceOf(RuntimeException::class.java)
       }
     }
@@ -225,21 +225,21 @@ class OracleConnectionAspectTest {
 
       @Test
       fun `should not open proxy connection`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(oracleConnection, never()).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), any())
       }
 
       @Test
       fun `should not configure role`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(roleConfigurer, never()).setRoleForConnection(any())
       }
 
       @Test
       fun `should set schema but not Nomis context`() {
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(nomisConfigurer).setDefaultSchema(pooledConnection)
         verify(nomisConfigurer, never()).setNomisContext(any(), anyString(), anyString(), anyString(), anyString(), anyBoolean())
@@ -249,7 +249,7 @@ class OracleConnectionAspectTest {
       fun `should not throw if replica`() {
         whenever(RoutingDataSource.isReplica()).thenReturn(true)
 
-        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection)
+        connectionAspect.configureNomisConnection(pooledConnection)
 
         verify(nomisConfigurer).setDefaultSchema(pooledConnection)
       }


### PR DESCRIPTION
We know that the NOMIS connections are being configured correctly now so we can remove some of the extra logging. I think all we need to know is:
* when a proxy user is used
* when a special connection is opened
* when a special connection is closed

We can assume that everything works as any exceptions will be logged in App Insights as will the failing request.