### PR TITLE
Adding a test to detect duplicate OpenAPI schemas

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/adjudications/AdjudicationDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/adjudications/AdjudicationDetail.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
-@Schema(description = "Detail about an individual Adjudication")
+@Schema(name = "IndividualAdjudication", description = "Detail about an individual Adjudication")
 @JsonInclude(NON_NULL)
 @Builder(toBuilder = true)
 @Data

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/OpenApiDocsDuplicateTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/OpenApiDocsDuplicateTest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.hmpps.prison.api.resource
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.hmpps.prison.web.config.AnnotationScanner.findAnnotatedClasses
+
+class OpenApiDocsDuplicateTest {
+  @Test
+  fun `Schemas need to have unique names - duplicates do not render correctly`() {
+    val duplicates = findAnnotatedClasses(
+      Schema::class.java,
+      arrayOf("uk.gov.justice.hmpps.prison.api")
+    ).filter {
+      // This incorrectly displays the new Location schema in the v1 API but don't want to break possible codegen used by external parties
+      it != uk.gov.justice.hmpps.prison.api.model.v1.Location::class.java
+    }.map {
+      val schema = it.annotations.find { it is Schema } as Schema
+      schema.name.ifEmpty { it.simpleName }
+    }
+      .groupBy { it }.filter { it.value.size > 1 }.values
+
+    assertThat(duplicates).isEmpty()
+  }
+}


### PR DESCRIPTION
Duplicate schemas do not render in the swagger docs - only one version will be displayed everywhere

A couple of duplicates were fixed a couple of weeks ago and this changes another and ignores an instance that affects display of the V1 APIs