### PR TITLE
SDIT-645: 🐛 Use selected bookings rather than old bookings on offender

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
@@ -1,11 +1,15 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderBooking;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,6 +17,10 @@ public interface OffenderBookingRepository extends
     PagingAndSortingRepository<OffenderBooking, Long>,
     JpaSpecificationExecutor<OffenderBooking>,
     CrudRepository<OffenderBooking, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ob from OffenderBooking ob where ob.offender.nomsId = :nomsId")
+    List<OffenderBooking> findAllByOffenderNomsIdForUpdate(String nomsId);
 
     Optional<OffenderBooking> findByOffenderNomsIdAndActive(String nomsId, boolean active);
     Optional<OffenderBooking> findByOffenderNomsIdAndBookingSequence(String nomsId, Integer bookingSequence);

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/BookingIntoPrisonService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/BookingIntoPrisonService.kt
@@ -76,6 +76,9 @@ class BookingIntoPrisonService(
     return newBooking(offender(prisonerIdentifier).getOrThrow(), requestForNewBooking)
   }
   fun newBooking(offender: Offender, requestForNewBooking: RequestForNewBooking): InmateDetail {
+    // ensure that we can get a select for update on the bookings before we start
+    val bookings = offenderBookingRepository.findAllByOffenderNomsIdForUpdate(offender.nomsId)
+
     val previousBooking: OffenderBooking? = previousInactiveBooking(offender).getOrThrow()
     val imprisonmentStatus: ImprisonmentStatus =
       imprisonmentStatus(requestForNewBooking.imprisonmentStatus).getOrThrow()
@@ -90,7 +93,9 @@ class BookingIntoPrisonService(
     val bookNumber: String = bookNumberGenerationService.generateBookNumber()
     val staff = getLoggedInStaff().getOrThrow().staff
 
-    offender.bookings.forEach(OffenderBooking::incBookingSequence)
+    // now increment the sequence on each booking
+    bookings.forEach(OffenderBooking::incBookingSequence)
+
     return offenderBookingRepository.save(
       OffenderBooking()
         .withBookingBeginDate(receiveTime)

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/BookingIntoPrisonService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/receiveandtransfer/BookingIntoPrisonService.kt
@@ -79,7 +79,7 @@ class BookingIntoPrisonService(
     // ensure that we can get a select for update on the bookings before we start
     val bookings = offenderBookingRepository.findAllByOffenderNomsIdForUpdate(offender.nomsId)
 
-    val previousBooking: OffenderBooking? = previousInactiveBooking(offender).getOrThrow()
+    val previousBooking: OffenderBooking? = previousInactiveBooking(bookings).getOrThrow()
     val imprisonmentStatus: ImprisonmentStatus =
       imprisonmentStatus(requestForNewBooking.imprisonmentStatus).getOrThrow()
     val prison = prison(requestForNewBooking.prisonId).getOrThrow()
@@ -199,8 +199,8 @@ class BookingIntoPrisonService(
     offenderBookingRepository.findByOffenderNomsIdAndBookingSequenceOrNull(prisonerIdentifier, 1)?.inActiveOut()
       ?: failure(EntityNotFoundException.withMessage("No bookings found for prisoner number $prisonerIdentifier"))
 
-  private fun previousInactiveBooking(offender: Offender): Result<OffenderBooking?> =
-    offender.latestBookingOrNull?.inActiveOut() ?: success(null)
+  private fun previousInactiveBooking(bookings: List<OffenderBooking>): Result<OffenderBooking?> =
+    bookings.minByOrNull { it.bookingSequence }?.inActiveOut() ?: success(null)
 
   private fun fromLocation(location: String?): Result<AgencyLocation> = location?.takeIf { it.isNotBlank() }?.let {
     agencyLocationRepository.findByIdAndDeactivationDateIsNullOrNull(it)?.let { location -> success(location) }
@@ -274,9 +274,6 @@ private fun CopyTableRepository.shouldCopyForAdmission(): Boolean =
     MovementType.ADM.code,
     true,
   ).isNotEmpty()
-
-private val Offender.latestBookingOrNull: OffenderBooking?
-  get() = this.latestBooking.orElse(null)
 
 private fun OffenderBooking.inActiveOut(): Result<OffenderBooking> {
   if (this.isActive) {


### PR DESCRIPTION
- Revert "Revert "SDIT-645: 🐛 Attempt to prevent duplicate bookings by grabbing lock on select (#1526)" (#1528)"
- SDIT-645: 🐛 Use selected bookings rather than old bookings on offender
