### PR TITLE
[DSE-1129] remove all required swagger docs fields for InmateDetail

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/Alert.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/Alert.java
@@ -31,47 +31,47 @@ public class Alert {
     @JsonIgnore
     private Map<String, Object> additionalProperties;
 
-    @Schema(required = true, description = "Alert Id", example = "1")
+    @Schema(description = "Alert Id", example = "1")
     @JsonProperty("alertId")
     @NotNull
     private Long alertId;
 
-    @Schema(required = true, description = "Offender booking id.", example = "14")
+    @Schema(description = "Offender booking id.", example = "14")
     @JsonProperty("bookingId")
     @NotNull
     private Long bookingId;
 
-    @Schema(required = true, description = "Offender Unique Reference", example = "G3878UK")
+    @Schema(description = "Offender Unique Reference", example = "G3878UK")
     @JsonProperty("offenderNo")
     @NotBlank
     private String offenderNo;
 
-    @Schema(required = true, description = "Alert Type", example = "X")
+    @Schema(description = "Alert Type", example = "X")
     @JsonProperty("alertType")
     @NotBlank
     private String alertType;
 
-    @Schema(required = true, description = "Alert Type Description", example = "Security")
+    @Schema(description = "Alert Type Description", example = "Security")
     @JsonProperty("alertTypeDescription")
     @NotBlank
     private String alertTypeDescription;
 
-    @Schema(required = true, description = "Alert Code", example = "XER")
+    @Schema(description = "Alert Code", example = "XER")
     @JsonProperty("alertCode")
     @NotBlank
     private String alertCode;
 
-    @Schema(required = true, description = "Alert Code Description", example = "Escape Risk")
+    @Schema(description = "Alert Code Description", example = "Escape Risk")
     @JsonProperty("alertCodeDescription")
     @NotBlank
     private String alertCodeDescription;
 
-    @Schema(required = true, description = "Alert comments", example = "Profession lock pick.")
+    @Schema(description = "Alert comments", example = "Profession lock pick.")
     @JsonProperty("comment")
     @NotBlank
     private String comment;
 
-    @Schema(required = true, description = "Date of the alert, which might differ to the date it was created", example = "2019-08-20")
+    @Schema(description = "Date of the alert, which might differ to the date it was created", example = "2019-08-20")
     @JsonProperty("dateCreated")
     @NotNull
     private LocalDate dateCreated;
@@ -80,12 +80,12 @@ public class Alert {
     @JsonProperty("dateExpires")
     private LocalDate dateExpires;
 
-    @Schema(required = true, description = "True / False based on presence of expiry date", example = "true")
+    @Schema(description = "True / False based on presence of expiry date", example = "true")
     @JsonProperty("expired")
     @NotNull
     private boolean expired;
 
-    @Schema(required = true, description = "True / False based on alert status", example = "false")
+    @Schema(description = "True / False based on alert status", example = "false")
     @JsonProperty("active")
     @NotNull
     private boolean active;

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/Alias.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/Alias.java
@@ -26,26 +26,26 @@ import java.time.LocalDate;
 @Data
 public class Alias {
     @NotBlank
-    @Schema(required = true, description = "First name of offender alias", example = "Mike")
+    @Schema(description = "First name of offender alias", example = "Mike")
     private String firstName;
 
     @Schema(description = "Middle names of offender alias", example = "John")
     private String middleName;
 
     @NotBlank
-    @Schema(required = true, description = "Last name of offender alias", example = "Smith")
+    @Schema(description = "Last name of offender alias", example = "Smith")
     private String lastName;
 
     @NotNull
-    @Schema(required = true, description = "Age of Offender", example = "32")
+    @Schema(description = "Age of Offender", example = "32")
     private Integer age;
 
     @NotNull
-    @Schema(required = true, description = "Date of Birth of Offender", example = "1980-02-28")
+    @Schema(description = "Date of Birth of Offender", example = "1980-02-28")
     private LocalDate dob;
 
     @NotBlank
-    @Schema(required = true, description = "Gender", example = "Male")
+    @Schema(description = "Gender", example = "Male")
     private String gender;
 
     @Schema(description = "Ethnicity", example = "Mixed: White and Black African")
@@ -55,6 +55,6 @@ public class Alias {
     private String nameType;
 
     @NotNull
-    @Schema(required = true, description = "Date of creation", example = "2019-02-15")
+    @Schema(description = "Date of creation", example = "2019-02-15")
     private LocalDate createDate;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/AssignedLivingUnit.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/AssignedLivingUnit.java
@@ -57,7 +57,7 @@ public class AssignedLivingUnit {
     /**
      * Agency Id
      */
-    @Schema(required = true, description = "Agency Id")
+    @Schema(description = "Agency Id")
     @JsonProperty("agencyId")
     public String getAgencyId() {
         return agencyId;
@@ -70,7 +70,7 @@ public class AssignedLivingUnit {
     /**
      * location Id
      */
-    @Schema(required = true, description = "location Id")
+    @Schema(description = "location Id")
     @JsonProperty("locationId")
     public Long getLocationId() {
         return locationId;
@@ -83,7 +83,7 @@ public class AssignedLivingUnit {
     /**
      * Living Unit Desc
      */
-    @Schema(required = true, description = "Living Unit Desc")
+    @Schema(description = "Living Unit Desc")
     @JsonProperty("description")
     public String getDescription() {
         return description;
@@ -96,7 +96,7 @@ public class AssignedLivingUnit {
     /**
      * Name of the agency where this living unit resides
      */
-    @Schema(required = true, description = "Name of the agency where this living unit resides")
+    @Schema(description = "Name of the agency where this living unit resides")
     @JsonProperty("agencyName")
     public String getAgencyName() {
         return agencyName;

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/InmateDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/InmateDetail.java
@@ -33,7 +33,7 @@ import static java.lang.String.format;
 @Data
 public class InmateDetail {
 
-    @Schema(required = true, description = "Offender Unique Reference", example = "A1234AA")
+    @Schema(description = "Offender Unique Reference", example = "A1234AA")
     @NotBlank
     private String offenderNo;
 
@@ -43,33 +43,33 @@ public class InmateDetail {
     @Schema(description = "Booking Number")
     private String bookingNo;
 
-    @Schema(required = true, description = "Internal Offender ID")
+    @Schema(description = "Internal Offender ID")
     @NotBlank
     private Long offenderId;
 
-    @Schema(required = true, description = "Internal Root Offender ID")
+    @Schema(description = "Internal Root Offender ID")
     @NotBlank
     private Long rootOffenderId;
 
-    @Schema(required = true, description = "First Name")
+    @Schema(description = "First Name")
     @NotBlank
     private String firstName;
 
     @Schema(description = "Middle Name(s)")
     private String middleName;
 
-    @Schema(required = true, description = "Last Name")
+    @Schema(description = "Last Name")
     @NotBlank
     private String lastName;
 
-    @Schema(required = true, description = "Date of Birth of prisoner", example = "1970-03-15")
+    @Schema(description = "Date of Birth of prisoner", example = "1970-03-15")
     @NotNull
     private LocalDate dateOfBirth;
 
     @Schema(description = "Age of prisoner. Note: Full Details Only")
     private Integer age;
 
-    @Schema(required = true, description = "Indicates that the person is currently in prison")
+    @Schema(description = "Indicates that the person is currently in prison")
     @NotNull
     private boolean activeFlag;
 
@@ -145,7 +145,7 @@ public class InmateDetail {
     @Schema(description = "Country of birth", example = "GBR")
     private String birthCountryCode;
 
-    @Schema(description = "In/Out Status", required = true, example = "IN", allowableValues = {"IN","OUT","TRN"})
+    @Schema(description = "In/Out Status", example = "IN", allowableValues = {"IN","OUT","TRN"})
     private String inOutStatus;
 
     @Schema(description = "Identifiers. Note: Only returned when requesting extra details")
@@ -166,7 +166,7 @@ public class InmateDetail {
     @Schema(description = "Aliases. Note: Only returned when requesting extra details")
     private List<Alias> aliases;
 
-    @Schema(description = "Status of prisoner", required = true, example = "ACTIVE IN", allowableValues = {"ACTIVE IN","ACTIVE OUT"})
+    @Schema(description = "Status of prisoner", example = "ACTIVE IN", allowableValues = {"ACTIVE IN","ACTIVE OUT"})
     private String status;
 
     @Schema(description = "Last movement status of the prison", example = "CRT-CA")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenceHistoryDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenceHistoryDetail.java
@@ -13,30 +13,30 @@ import java.time.LocalDate;
 @Data
 public class OffenceHistoryDetail {
 
-    @Schema(required = true, description = "Prisoner booking id", example = "1123456")
+    @Schema(description = "Prisoner booking id", example = "1123456")
     @NotNull
     private Long bookingId;
 
-    @Schema(required = true, description = "Date the offence took place", example = "2018-02-10")
+    @Schema(description = "Date the offence took place", example = "2018-02-10")
     @NotNull
     private LocalDate offenceDate;
 
     @Schema(description = "End date if range the offence was believed to have taken place", example = "2018-03-10")
     private LocalDate offenceRangeDate;
 
-    @Schema(required = true, description = "Description associated with the offence code", example = "Commit an act / series of acts with intent to pervert the course of public justice")
+    @Schema(description = "Description associated with the offence code", example = "Commit an act / series of acts with intent to pervert the course of public justice")
     @NotBlank
     private String offenceDescription;
 
-    @Schema(required = true, description = "Reference Code", example = "RR84070")
+    @Schema(description = "Reference Code", example = "RR84070")
     @NotBlank
     private String offenceCode;
 
-    @Schema(required = true, description = "Statute code", example = "RR84")
+    @Schema(description = "Statute code", example = "RR84")
     @NotBlank
     private String statuteCode;
 
-    @Schema(required = true, description = "Identifies the main offence per booking")
+    @Schema(description = "Identifies the main offence per booking")
     private Boolean mostSerious;
 
     @Schema(description = "Primary result code ")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderIdentifier.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderIdentifier.java
@@ -19,11 +19,11 @@ import java.time.LocalDateTime;
 @Data
 public class OffenderIdentifier {
     @NotBlank
-    @Schema(required = true, description = "Type of offender identifier", example = "PNC")
+    @Schema(description = "Type of offender identifier", example = "PNC")
     private String type;
 
     @NotBlank
-    @Schema(required = true, description = "The value of the offender identifier", example = "1231/XX/121")
+    @Schema(description = "The value of the offender identifier", example = "1231/XX/121")
     private String value;
 
     @Schema(description = "The offender number for this identifier", example = "A1234AB")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderSentenceTerms.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderSentenceTerms.java
@@ -17,13 +17,13 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Data
 public class OffenderSentenceTerms {
-    @Schema(required = true, description = "Offender booking id.", example = "1132400")
+    @Schema(description = "Offender booking id.", example = "1132400")
     private Long bookingId;
 
-    @Schema(required = true, description = "Sentence number within booking id.", example = "2")
+    @Schema(description = "Sentence number within booking id.", example = "2")
     private Integer sentenceSequence;
 
-    @Schema(required = true, description = "Sentence term number within sentence.", example = "1")
+    @Schema(description = "Sentence term number within sentence.", example = "1")
     private Integer termSequence;
 
     @Schema(description = "Sentence number which this sentence follows if consecutive, otherwise concurrent.", example = "2")
@@ -35,7 +35,7 @@ public class OffenderSentenceTerms {
     @Schema(description = "Sentence type description.", example = "2")
     private String sentenceTypeDescription;
 
-    @Schema(required = true, description = "Start date of sentence term.", example = "2018-12-31")
+    @Schema(description = "Start date of sentence term.", example = "2018-12-31")
     private LocalDate startDate;
 
     @Schema(description = "Sentence length years.")
@@ -50,21 +50,21 @@ public class OffenderSentenceTerms {
     @Schema(description = "Sentence length days.")
     private Integer days;
 
-    @Schema(required = true, description = "Whether this is a life sentence.")
+    @Schema(description = "Whether this is a life sentence.")
     private Boolean lifeSentence;
 
-    @Schema(required = true, description = "Court case id")
+    @Schema(description = "Court case id")
     private String caseId;
 
-    @Schema(required = true, description = "Fine amount.")
+    @Schema(description = "Fine amount.")
     private Double fineAmount;
 
-    @Schema(required = true, description = "Sentence term code.", example = "IMP")
+    @Schema(description = "Sentence term code.", example = "IMP")
     private String sentenceTermCode;
 
-    @Schema(required = true, description = "Sentence line number", example = "1")
+    @Schema(description = "Sentence line number", example = "1")
     private Long lineSeq;
 
-    @Schema(required = true, description = "Sentence start date", example = "2018-12-31")
+    @Schema(description = "Sentence start date", example = "2018-12-31")
     private LocalDate sentenceStartDate;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/PhysicalAttributes.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/PhysicalAttributes.java
@@ -28,34 +28,34 @@ import java.math.BigDecimal;
 public class PhysicalAttributes {
 
     @NotBlank
-    @Schema(required = true, description = "Gender Code", example = "M")
+    @Schema(description = "Gender Code", example = "M")
     private String sexCode;
 
     @NotBlank
-    @Schema(required = true, description = "Gender", example = "Male")
+    @Schema(description = "Gender", example = "Male")
     private String gender;
 
-    @Schema(required = true, description = "Ethnicity Code", example = "W1")
+    @Schema(description = "Ethnicity Code", example = "W1")
     private String raceCode;
 
-    @Schema(required = true, description = "Ethnicity", example = "White: Eng./Welsh/Scot./N.Irish/British")
+    @Schema(description = "Ethnicity", example = "White: Eng./Welsh/Scot./N.Irish/British")
     private String ethnicity;
 
-    @Schema(required = true, description = "Height in Feet", example = "5")
+    @Schema(description = "Height in Feet", example = "5")
     private Integer heightFeet;
 
-    @Schema(required = true, description = "Height in Inches", example = "60")
+    @Schema(description = "Height in Inches", example = "60")
     private Integer heightInches;
 
-    @Schema(required = true, description = "Height in Metres (to 2dp)", example = "1.76")
+    @Schema(description = "Height in Metres (to 2dp)", example = "1.76")
     private BigDecimal heightMetres;
 
-    @Schema(required = true, description = "Height in Centimetres", example = "176")
+    @Schema(description = "Height in Centimetres", example = "176")
     private Integer heightCentimetres;
 
-    @Schema(required = true, description = "Weight in Pounds", example = "50")
+    @Schema(description = "Weight in Pounds", example = "50")
     private Integer weightPounds;
 
-    @Schema(required = true, description = "Weight in Kilograms", example = "67")
+    @Schema(description = "Weight in Kilograms", example = "67")
     private Integer weightKilograms;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/PhysicalCharacteristic.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/PhysicalCharacteristic.java
@@ -41,7 +41,7 @@ public class PhysicalCharacteristic {
     /**
      * Type code of physical characteristic
      */
-    @Schema(required = true, description = "Type code of physical characteristic")
+    @Schema(description = "Type code of physical characteristic")
     @JsonProperty("type")
     public String getType() {
         return type;
@@ -54,7 +54,7 @@ public class PhysicalCharacteristic {
     /**
      * Type of physical characteristic
      */
-    @Schema(required = true, description = "Type of physical characteristic")
+    @Schema(description = "Type of physical characteristic")
     @JsonProperty("characteristic")
     public String getCharacteristic() {
         return characteristic;
@@ -67,7 +67,7 @@ public class PhysicalCharacteristic {
     /**
      * Detailed information about the physical characteristic
      */
-    @Schema(required = true, description = "Detailed information about the physical characteristic")
+    @Schema(description = "Detailed information about the physical characteristic")
     @JsonProperty("detail")
     public String getDetail() {
         return detail;

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/PhysicalMark.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/PhysicalMark.java
@@ -61,7 +61,7 @@ public class PhysicalMark {
     /**
      * Type of Mark
      */
-    @Schema(required = true, description = "Type of Mark")
+    @Schema(description = "Type of Mark")
     @JsonProperty("type")
     public String getType() {
         return type;
@@ -74,7 +74,7 @@ public class PhysicalMark {
     /**
      * Left or Right Side
      */
-    @Schema(required = true, description = "Left or Right Side")
+    @Schema(description = "Left or Right Side")
     @JsonProperty("side")
     public String getSide() {
         return side;
@@ -87,7 +87,7 @@ public class PhysicalMark {
     /**
      * Where on the body
      */
-    @Schema(required = true, description = "Where on the body")
+    @Schema(description = "Where on the body")
     @JsonProperty("bodyPart")
     public String getBodyPart() {
         return bodyPart;
@@ -100,7 +100,7 @@ public class PhysicalMark {
     /**
      * Image orientation
      */
-    @Schema(required = true, description = "Image orientation")
+    @Schema(description = "Image orientation")
     @JsonProperty("orientation")
     public String getOrientation() {
         return orientation;
@@ -113,7 +113,7 @@ public class PhysicalMark {
     /**
      * More information
      */
-    @Schema(required = true, description = "More information")
+    @Schema(description = "More information")
     @JsonProperty("comment")
     public String getComment() {
         return comment;

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/ProfileInformation.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/ProfileInformation.java
@@ -21,15 +21,15 @@ import jakarta.validation.constraints.NotBlank;
 public class ProfileInformation {
 
     @NotBlank
-    @Schema(required = true, description = "Type of profile information")
+    @Schema(description = "Type of profile information")
     private String type;
 
     @NotBlank
-    @Schema(required = true, description = "Profile Question")
+    @Schema(description = "Profile Question")
     private String question;
 
     @NotBlank
-    @Schema(required = true, description = "Profile Result Answer")
+    @Schema(description = "Profile Result Answer")
     private String resultValue;
 
     public ProfileInformation(@NotBlank String type, @NotBlank String question, @NotBlank String resultValue) {

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/SentenceCalcDates.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/SentenceCalcDates.java
@@ -23,10 +23,10 @@ import java.time.LocalDate;
 @Data
 public class SentenceCalcDates extends BaseSentenceCalcDates {
 
-    @Schema(required = true, description = "Offender booking id.", example = "1234123")
+    @Schema(description = "Offender booking id.", example = "1234123")
     @NotNull
     private Long bookingId;
-    @Schema(description = "Sentence start date.", example = "2010-02-03", required = true)
+    @Schema(description = "Sentence start date.", example = "2010-02-03")
     private LocalDate sentenceStartDate;
     @Schema(description = "ADA - days added to sentence term due to adjustments.", example = "5")
     private Integer additionalDaysAwarded;
@@ -66,7 +66,7 @@ public class SentenceCalcDates extends BaseSentenceCalcDates {
 
     @Schema(description = "HDCED (override) - date on which offender will be eligible for home detention curfew.", example = "2020-02-03")
     private LocalDate homeDetentionCurfewEligibilityOverrideDate;
-    @Schema(description = "Indicates which type of non-DTO release date is the effective release date. One of 'ARD', 'CRD', 'NPD' or 'PRRD'.", example = "CRD", required = true)
+    @Schema(description = "Indicates which type of non-DTO release date is the effective release date. One of 'ARD', 'CRD', 'NPD' or 'PRRD'.", example = "CRD")
     private NonDtoReleaseDateType nonDtoReleaseDateType;
     @Schema(description = "Confirmed release date for offender.", example = "2020-04-20")
     private LocalDate confirmedReleaseDate;


### PR DESCRIPTION
This removes all deprecated "required" fields in Swagger Schema annotations for the InmateDetail and all sub models (basically all the models required to call the `/api/offenders/:offenderNo` endpoint. This ensures that any client code that gets generated using the openapi-generator will not be generated with required fields. Instead the models generated will have optional fields.