### PR TITLE
NN-5049 allow null adjudicator

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OicHearingResultRequest.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OicHearingResultRequest.java
@@ -27,7 +27,6 @@ public class OicHearingResultRequest {
     @NotNull
     private FindingCode findingCode;
 
-    @Schema(description = "username of adjudicator")
-    @NotNull
+    @Schema(description = "optional username of adjudicator")
     private String adjudicator;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
@@ -51,6 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -332,11 +333,14 @@ public class AdjudicationsService {
             throw new ValidationException(format("Hearing result for hearing id %d already exist for adjudication number %d", oicHearingId, adjudicationNumber));
         }
 
-        final var staff = staffUserAccountRepository.findByUsername(oicHearingResultRequest.getAdjudicator())
-            .orElseThrow(() -> new EntityNotFoundException(format("Adjudicator not found for username %s", oicHearingResultRequest.getAdjudicator())));
+        Optional.ofNullable(oicHearingResultRequest.getAdjudicator()).ifPresent(adjudicator -> {
+            final var staff = staffUserAccountRepository.findByUsername(adjudicator)
+                .orElseThrow(() -> new EntityNotFoundException(format("Adjudicator not found for username %s", adjudicator)));
 
-        oicHearing.setAdjudicator(staff.getStaff());
-        oicHearingRepository.save(oicHearing);
+            oicHearing.setAdjudicator(staff.getStaff());
+            oicHearingRepository.save(oicHearing);
+        });
+
 
         Long oicOffenceId;
         try {
@@ -374,11 +378,13 @@ public class AdjudicationsService {
         final var oicHearingResult = oicHearingResultRepository.findById(new OicHearingResult.PK(oicHearingId, 1L))
             .orElseThrow(new EntityNotFoundException(format("No hearing result found for hearing id %d and adjudication number %d", oicHearingId, adjudicationNumber)));
 
-        final var staff = staffUserAccountRepository.findByUsername(oicHearingResultRequest.getAdjudicator())
-            .orElseThrow(() -> new EntityNotFoundException(format("Adjudicator not found for username %s", oicHearingResultRequest.getAdjudicator())));
+        Optional.ofNullable(oicHearingResultRequest.getAdjudicator()).ifPresent(adjudicator -> {
+            final var staff = staffUserAccountRepository.findByUsername(adjudicator)
+                .orElseThrow(() -> new EntityNotFoundException(format("Adjudicator not found for username %s", adjudicator)));
 
-        oicHearing.setAdjudicator(staff.getStaff());
-        oicHearingRepository.save(oicHearing);
+            oicHearing.setAdjudicator(staff.getStaff());
+            oicHearingRepository.save(oicHearing);
+        });
 
         oicHearingResult.setPleaFindingCode(oicHearingResultRequest.getPleaFindingCode());
         oicHearingResult.setFindingCode(oicHearingResultRequest.getFindingCode());

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/AdjudicationsResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/AdjudicationsResourceTest.java
@@ -807,7 +807,6 @@ public class AdjudicationsResourceTest extends ResourceTest  {
                 .expectStatus().isOk();
         }
 
-        // TODO test delete HearingResult with sanctions
 
         private ResponseSpec deleteHearingResult(List<String> headers, Long adjudicationNumber, Long hearingId) {
             return webTestClient.delete()

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
@@ -1159,6 +1159,8 @@ public class AdjudicationsServiceTest {
         public void createHearingResult() {
             initCreateHearingResultTest();
 
+            when(oicHearingRepository.save(any())).thenReturn(OicHearing.builder().build());
+
             when(staffUserAccountRepository.findByUsername("adjudicator")).thenReturn(
                 Optional.of(
                     StaffUserAccount.builder().staff(
@@ -1210,7 +1212,6 @@ public class AdjudicationsServiceTest {
             when(oicHearingResultRepository.findById(new OicHearingResult.PK(3L, 1L)))
                 .thenReturn(Optional.empty());
 
-            when(oicHearingRepository.save(any())).thenReturn(OicHearing.builder().build());
             when(oicHearingResultRepository.save(any())).thenReturn(OicHearingResult.builder()
                 .findingCode(FindingCode.DISMISSED)
                 .pleaFindingCode(PleaFindingCode.GUILTY)
@@ -1222,9 +1223,9 @@ public class AdjudicationsServiceTest {
             final var hearingCapture = ArgumentCaptor.forClass(OicHearing.class);
             final var hearingResultCapture = ArgumentCaptor.forClass(OicHearingResult.class);
 
-            verify(oicHearingRepository, atLeastOnce()).save(hearingCapture.capture());
             verify(oicHearingResultRepository, atLeastOnce()).save(hearingResultCapture.capture());
             if(withAdjudicator) {
+                verify(oicHearingRepository, atLeastOnce()).save(hearingCapture.capture());
                 assertThat(hearingCapture.getValue().getAdjudicator().getStaffId()).isEqualTo(10);
             }
 
@@ -1335,6 +1336,7 @@ public class AdjudicationsServiceTest {
         @Test
         public void amendHearingResult() {
             initAmendHearingResult();
+
             when(staffUserAccountRepository.findByUsername("other_adjudicator")).thenReturn(
                 Optional.of(
                     StaffUserAccount.builder().staff(
@@ -1370,6 +1372,7 @@ public class AdjudicationsServiceTest {
                 .thenReturn(Optional.of(
                     Adjudication.builder().build()
                 ));
+
             when(oicHearingRepository.findById(3L))
                 .thenReturn(Optional.of(
                     OicHearing.builder().adjudicationNumber(2L).build()
@@ -1389,8 +1392,8 @@ public class AdjudicationsServiceTest {
             final var hearingCapture = ArgumentCaptor.forClass(OicHearing.class);
             final var hearingResultCapture = ArgumentCaptor.forClass(OicHearingResult.class);
 
-            verify(oicHearingRepository, atLeastOnce()).save(hearingCapture.capture());
             if(withAdjudicator) {
+                verify(oicHearingRepository, atLeastOnce()).save(hearingCapture.capture());
                 assertThat(hearingCapture.getValue().getAdjudicator().getStaffId()).isEqualTo(11);
             }
             verify(oicHearingResultRepository, atLeastOnce()).save(hearingResultCapture.capture());


### PR DESCRIPTION
When setting the independent adjudicator there will be no associated staff id therefore allow nulls when creating or amending hearing results