### PR TITLE
Nn 5036 npe fix

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
@@ -327,7 +327,7 @@ public class AdjudicationsResource {
     @ProxyUser
     @PreAuthorize("hasRole('MAINTAIN_ADJUDICATIONS') and hasAuthority('SCOPE_write')")
     @ResponseStatus(HttpStatus.OK)
-    public void deleteOicSanction(
+    public void deleteSingleOicSanction(
         @PathVariable("adjudicationNumber") final Long adjudicationNumber,
         @PathVariable("sanctionSeq") final Long sanctionSeq
     ) {

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OicSanctionRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OicSanctionRepository.java
@@ -1,13 +1,13 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.OicSanction.PK;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.OicSanction;
 
 import java.util.List;
 
-public interface OicSanctionRepository extends CrudRepository<OicSanction, PK> {
+public interface OicSanctionRepository extends JpaRepository<OicSanction, PK> {
 
     List<OicSanction> findByOicHearingId(Long oicHearingId);
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
@@ -464,7 +464,8 @@ public class AdjudicationsService {
         List<OicSanction> oicSanctions = new ArrayList<>();
         int index = 0;
         for (var request : oicSanctionRequests) {
-            oicSanctions.add(oicSanctionRepository.save(OicSanction.builder()
+            // flushing removes error in trigger OFFENDER_OIC_SANCTIONS_T1 on insert
+            oicSanctions.add(oicSanctionRepository.saveAndFlush(OicSanction.builder()
                 .offenderBookId(result.getOffenderBookId())
                 .sanctionSeq(nextSanctionSeq + index)
                 .oicSanctionCode(request.getOicSanctionCode())
@@ -510,7 +511,8 @@ public class AdjudicationsService {
         List<OicSanction> oicSanctions = new ArrayList<>();
         int index = 0;
         for (var request : oicSanctionRequests) {
-            oicSanctions.add(oicSanctionRepository.save(OicSanction.builder()
+            // flushing removes error in trigger OFFENDER_OIC_SANCTIONS_T1 on insert
+            oicSanctions.add(oicSanctionRepository.saveAndFlush(OicSanction.builder()
                 .offenderBookId(result.getOffenderBookId())
                 .sanctionSeq(nextSanctionSeq + index)
                 .oicSanctionCode(request.getOicSanctionCode())

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
@@ -1622,8 +1622,8 @@ public class AdjudicationsServiceTest {
                 .oicIncidentId(2L)
                 .build();
 
-            when(oicSanctionRepository.save(oicSanction_withoutCompensation)).thenReturn(oicSanction_withoutCompensation);
-            when(oicSanctionRepository.save(oicSanction_withCompensation)).thenReturn(oicSanction_withCompensation);
+            when(oicSanctionRepository.saveAndFlush(oicSanction_withoutCompensation)).thenReturn(oicSanction_withoutCompensation);
+            when(oicSanctionRepository.saveAndFlush(oicSanction_withCompensation)).thenReturn(oicSanction_withCompensation);
 
             List<Sanction> result = service.createOicSanctions(2L, List.of(OicSanctionRequest.builder()
                     .oicSanctionCode(OicSanctionCode.ADA)
@@ -1643,7 +1643,7 @@ public class AdjudicationsServiceTest {
                     .build()));
 
             final var sanctionCapture = ArgumentCaptor.forClass(OicSanction.class);
-            verify(oicSanctionRepository, atLeastOnce()).save(sanctionCapture.capture());
+            verify(oicSanctionRepository, times(2)).saveAndFlush(sanctionCapture.capture());
 
             assertThat(sanctionCapture.getValue().getOffenderBookId()).isEqualTo(200L);
             assertThat(sanctionCapture.getValue().getSanctionSeq()).isEqualTo(7L);
@@ -1778,8 +1778,8 @@ public class AdjudicationsServiceTest {
                 .oicIncidentId(2L)
                 .build();
 
-            when(oicSanctionRepository.save(oicSanction_withoutCompensation)).thenReturn(oicSanction_withoutCompensation);
-            when(oicSanctionRepository.save(oicSanction_withCompensation)).thenReturn(oicSanction_withCompensation);
+            when(oicSanctionRepository.saveAndFlush(oicSanction_withoutCompensation)).thenReturn(oicSanction_withoutCompensation);
+            when(oicSanctionRepository.saveAndFlush(oicSanction_withCompensation)).thenReturn(oicSanction_withCompensation);
 
             List<Sanction> result = service.updateOicSanctions(2L, List.of(OicSanctionRequest.builder()
                     .oicSanctionCode(OicSanctionCode.ADA)
@@ -1799,11 +1799,11 @@ public class AdjudicationsServiceTest {
                     .build()));
 
             ArgumentCaptor<List<OicSanction>> deleteCapture = ArgumentCaptor.forClass(List.class);
-            verify(oicSanctionRepository, atLeastOnce()).deleteAll(deleteCapture.capture());
+            verify(oicSanctionRepository, times(1)).deleteAll(deleteCapture.capture());
             assertThat(deleteCapture.getValue().get(0).getOffenderBookId()).isEqualTo(200L);
 
             final var saveCapture = ArgumentCaptor.forClass(OicSanction.class);
-            verify(oicSanctionRepository, times(2)).save(saveCapture.capture());
+            verify(oicSanctionRepository, times(2)).saveAndFlush(saveCapture.capture());
 
             assertThat(saveCapture.getValue().getOffenderBookId()).isEqualTo(200L);
             assertThat(saveCapture.getValue().getSanctionSeq()).isEqualTo(7L);


### PR DESCRIPTION
1. adding test case to avoid NPE in sanction compensation amount (optional value).
2. adding flushing to avoid (hopefully) error in trigger:

exceptions
| where cloud_RoleName == "prison-api"  and operation_Id == "4994d07eaf4243b2b5ec419eb600efd6"

ORA-20999: ORA-04091: table OMS_OWNER.OFFENDER_OIC_SANCTIONS is mutating, trigger/function may not see it
ORA-06512: at "OMS_OWNER.OFFENDER_OIC_SANCTIONS_T1", line 29
ORA-06512: at "OMS_OWNER.TAG_ERROR", line 169
ORA-06512: at "OMS_OWNER.OFFENDER_OIC_SANCTIONS_T1", line 38
ORA-04088: error during execution of trigger 'OMS_OWNER.OFFENDER_OIC_SANCTIONS_T1'