### PR TITLE
SDI-777 Fetch author for case notes for `findAll`

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderCaseNote.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderCaseNote.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.model;
 
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,6 +40,7 @@ import static org.hibernate.annotations.NotFoundAction.IGNORE;
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "OFFENDER_CASE_NOTES")
 @ToString(exclude = { "offenderBooking", "agencyLocation" } )
+@NamedEntityGraph(name = "case-note-with-author", attributeNodes = @NamedAttributeNode(value = "author"))
 public class OffenderCaseNote extends AuditableEntity {
     private static final String AMEND_CASE_NOTE_FORMAT = "%s ...[%s updated the case notes on %s] %s";
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderCaseNoteRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderCaseNoteRepository.java
@@ -1,9 +1,16 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.repository;
 
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.lang.Nullable;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderCaseNote;
 
 import java.time.LocalDate;
@@ -30,5 +37,8 @@ public interface OffenderCaseNoteRepository extends
     Long countOffenderCaseNoteByOffenderBooking_BookingIdAndTypeCodeAndSubTypeCodeAndOccurrenceDateIsBetween(
         Long bookingId, String type, String subType, LocalDate fromDate, LocalDate toDate
     );
+    @NotNull
+    @EntityGraph(type = EntityGraphType.FETCH, value = "case-note-with-author")
+    Page<OffenderCaseNote> findAll(@Nullable Specification<OffenderCaseNote> spec, @NotNull Pageable pageable);
 }
 


### PR DESCRIPTION
Currently `author` is eager loaded as a N + 1 type query, when showing all case notes in DPS this leads to 100s of separate `select` from `staff_members` table. This change means that is all done via a `join` instead.

Avoiding high number of separate SQL select held when latency with database is high (e.g when in AWS)