### PR TITLE
SDI-778 Fetch booking/offender for bed histories by prison and date

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/BedAssignmentHistory.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/BedAssignmentHistory.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.model;
 
-import jakarta.persistence.FetchType;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedSubgraph;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,9 +17,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.NotFound;
+
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import static org.hibernate.annotations.NotFoundAction.IGNORE;
 
 @Data
 @Builder
@@ -27,6 +33,18 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Entity
 @Table(name = "BED_ASSIGNMENT_HISTORIES")
+@NamedEntityGraph(
+    name = "bed-history-with-booking",
+    attributeNodes = @NamedAttributeNode(value = "offenderBooking", subgraph = "booking-offender"),
+    subgraphs = {
+        @NamedSubgraph(
+            name = "booking-offender",
+            attributeNodes = {
+                @NamedAttributeNode("offender")
+            }
+        )
+    }
+)
 public class BedAssignmentHistory extends AuditableEntity {
 
     @Data
@@ -51,7 +69,8 @@ public class BedAssignmentHistory extends AuditableEntity {
     @Column(name = "LIVING_UNIT_ID")
     private Long livingUnitId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @NotFound(action = IGNORE)
+    @ManyToOne
     @JoinColumn(name = "LIVING_UNIT_ID", referencedColumnName = "INTERNAL_LOCATION_ID", insertable = false, updatable = false)
     private AgencyInternalLocation location;
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/BedAssignmentHistoriesRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/BedAssignmentHistoriesRepository.java
@@ -2,6 +2,8 @@ package uk.gov.justice.hmpps.prison.repository.jpa.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -31,5 +33,6 @@ public interface BedAssignmentHistoriesRepository extends
     @Query("select ba from BedAssignmentHistory ba where ba.livingUnitId = :livingUnitId and (ba.assignmentEndDateTime is null or :fromDate <= ba.assignmentEndDateTime) and :toDate >= ba.assignmentDateTime")
     List<BedAssignmentHistory> findByLivingUnitIdAndDateTimeRange(@Param("livingUnitId") long livingUnitId, @Param("fromDate") LocalDateTime from, @Param("toDate") LocalDateTime to);
 
+    @EntityGraph(type = EntityGraphType.FETCH, value = "bed-history-with-booking")
     List<BedAssignmentHistory> findBedAssignmentHistoriesByAssignmentDateAndLivingUnitIdIn(LocalDate assignmentDate, Set<Long> livingUnitIds);
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BedAssignmentHistoryService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BedAssignmentHistoryService.java
@@ -106,7 +106,7 @@ public class BedAssignmentHistoryService {
     }
 
     private BedAssignment transform(final BedAssignmentHistory assignment) {
-        final var agencyInternalLocation = locationRepository.findOneByLocationId(assignment.getLivingUnitId());
+        final var agencyInternalLocation = Optional.ofNullable(assignment.getLocation());
         final var agencyId = agencyInternalLocation.map(AgencyInternalLocation::getAgencyId).orElse(null);
         final var agencyDescription = agencyInternalLocation.map(AgencyInternalLocation::getDescription).orElse(null);
 


### PR DESCRIPTION
Calls to this endpoint e.g. /api/cell/NMI/history/2023-04-28
result in ( n * 3)  + 1 SQL for each bed history record, each booking and offender record was loaded by individual and there was a separate repo call for the internal location that was already loaded 