### PR TITLE
SAA-643 removing use of allowableValues on bools and enums.  This has  unwanted breaking side effects when generated classes from the open api spec. If also breaks the documentation.

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/Contact.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/Contact.java
@@ -67,19 +67,19 @@ public class Contact {
     @Schema(description = "id of the person contact", example = "5871791")
     private Long personId;
 
-    @Schema(required = true, description = "Active indicator flag.", example = "true", allowableValues = {"true","false"})
+    @Schema(required = true, description = "Active indicator flag.", example = "true")
     private boolean activeFlag;
 
     @Schema(description = "Date made inactive", example = "2019-01-31")
     private LocalDate expiryDate;
 
-    @Schema(required = true, description = "Approved Visitor", example = "true", allowableValues = {"true","false"})
+    @Schema(required = true, description = "Approved Visitor", example = "true")
     private boolean approvedVisitorFlag;
 
-    @Schema(required = true, description = "Can be contacted", example = "false", allowableValues = {"true","false"})
+    @Schema(required = true, description = "Can be contacted", example = "false")
     private boolean canBeContactedFlag;
 
-    @Schema(required = true, description = "Aware of charges against prisoner", example = "true", allowableValues = {"true","false"})
+    @Schema(required = true, description = "Aware of charges against prisoner", example = "true")
     private boolean awareOfChargesFlag;
 
     @Schema(description = "Link to root offender ID", example = "5871791")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/CreateExternalMovement.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/CreateExternalMovement.java
@@ -36,7 +36,7 @@ public class CreateExternalMovement {
     @Schema(description = "Movement reason", required = true, example = "SEC")
     @NotNull
     private String movementReason;
-    @Schema(description = "Direction code", required = true, example = "OUT", allowableValues = {"IN","OUT"})
+    @Schema(description = "Direction code", required = true, example = "OUT")
     @NotNull
     private MovementDirection directionCode;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderCategorise.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderCategorise.java
@@ -36,7 +36,7 @@ public class OffenderCategorise {
     @Schema(description = "Sequence number within booking")
     private Integer assessmentSeq;
 
-    @Schema(description = "assessment type", allowableValues = {"CATEGORY"})
+    @Schema(description = "assessment type")
     private Long assessmentTypeId;
 
     @Schema(description = "Categorisation status", allowableValues = {"P","A","I"})

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/bulkappointments/Repeat.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/bulkappointments/Repeat.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Repeat {
-    @Schema(required = true, description = "The period at which the appointment should repeat.", example = "WEEKLY", allowableValues = {"DAILY", "WEEKDAYS", "WEEKLY", "FORTNIGHTLY", "MONTHLY"})
+    @Schema(required = true, description = "The period at which the appointment should repeat.", example = "WEEKLY")
     @NotNull
     private RepeatPeriod repeatPeriod;
 


### PR DESCRIPTION
Removing use of allowableValues on bools and enums (it isn't needed as far as I can see).

With allowableValues on bools it attempts to generate enums in the generated classes and not bools.

Having allowableValues on enums has unwanted side effects in the documentation and impacts (breaks) auto generation of enum classes from the open-api spec.

Example before (note unwanted repetition of the enum values:

![image](https://user-images.githubusercontent.com/60104344/236145841-8f1dd07b-ef93-4963-8adb-cf60f2c6c875.png)

Example after:

![image](https://user-images.githubusercontent.com/60104344/236145923-104fc0cd-0921-44ca-8521-95fcc3b0437c.png)
