### PR TITLE
SDI-786 Fetch internal location profiles to avoid n + 1 SQL

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocation.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocation.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.model;
 
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +25,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
+import java.util.List;
 import java.util.Objects;
 
 import static org.hibernate.annotations.NotFoundAction.IGNORE;
@@ -34,6 +39,10 @@ import static org.hibernate.annotations.NotFoundAction.IGNORE;
 @Setter
 @RequiredArgsConstructor
 @Table(name = "AGENCY_INTERNAL_LOCATIONS")
+@NamedEntityGraph(
+    name = "agency-internal-location-with-profiles",
+    attributeNodes = @NamedAttributeNode(value = "profiles")
+)
 public class AgencyInternalLocation {
     @Id
     @Column(name = "INTERNAL_LOCATION_ID")
@@ -83,6 +92,10 @@ public class AgencyInternalLocation {
 
     @Column(name = "CAPACITY")
     private Integer capacity;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "INTERNAL_LOCATION_ID", referencedColumnName = "INTERNAL_LOCATION_ID")
+    private List<AgencyInternalLocationProfile> profiles;
 
     public boolean isCell() {
         return locationType != null && locationType.equals("CELL");

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/AgencyInternalLocationRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/AgencyInternalLocationRepository.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.AgencyInternalLocation;
@@ -11,6 +13,9 @@ import java.util.Optional;
 public interface AgencyInternalLocationRepository extends JpaRepository<AgencyInternalLocation, Long> {
 
     List<AgencyInternalLocation> findAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive(final String agencyId, final String locationType, final boolean active);
+
+    @EntityGraph(type = EntityGraphType.FETCH, value = "agency-internal-location-with-profiles")
+    List<AgencyInternalLocation> findWithProfilesAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive(final String agencyId, final String locationType, final boolean active);
 
     List<AgencyInternalLocation> findAgencyInternalLocationsByAgencyIdAndLocationType(final String agencyId, final String locationType);
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AgencyService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AgencyService.java
@@ -357,7 +357,7 @@ public class AgencyService {
     }
 
     public List<OffenderCell> getCellsWithCapacityInAgency(@NotNull final String agencyId, final String attribute) {
-        final var cells = agencyInternalLocationRepository.findAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive(agencyId, "CELL", true);
+        final var cells = agencyInternalLocationRepository.findWithProfilesAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive(agencyId, "CELL", true);
         return cells.stream()
                 .filter((l) -> l.isActiveCellWithSpace(true))
                 .map(cell -> transform(cell, true))
@@ -389,8 +389,7 @@ public class AgencyService {
     }
 
     private OffenderCell transform(final AgencyInternalLocation cell, final boolean treatZeroOperationalCapacityAsNull) {
-        final var attributes = agencyInternalLocationProfileRepository
-            .findAllByLocationId(cell.getLocationId())
+        final var attributes = cell.getProfiles()
             .stream()
             .filter(AgencyInternalLocationProfile::isAttribute)
             .map(AgencyInternalLocationProfile::getHousingAttributeReferenceCode)

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AgencyServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AgencyServiceTest.java
@@ -143,12 +143,11 @@ public class AgencyServiceTest {
 
     @Test
     public void shouldReturnAllActiveCellsWithSpaceForAgency() {
-        when(agencyInternalLocationRepository.findAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive("LEI", "CELL", true)).thenReturn(List.of(
-                AgencyInternalLocation.builder().locationId(-1L).locationType("CELL").operationalCapacity(2).currentOccupancy(1).active(true).build(),
-                AgencyInternalLocation.builder().locationId(-2L).locationType("CELL").operationalCapacity(2).currentOccupancy(1).active(true).build(),
-                AgencyInternalLocation.builder().locationId(-3L).locationType("CELL").operationalCapacity(2).currentOccupancy(2).active(true).build()
+        when(agencyInternalLocationRepository.findWithProfilesAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive("LEI", "CELL", true)).thenReturn(List.of(
+                AgencyInternalLocation.builder().locationId(-1L).locationType("CELL").operationalCapacity(2).currentOccupancy(1).active(true).profiles(buildAgencyInternalLocationProfiles()).build(),
+                AgencyInternalLocation.builder().locationId(-2L).locationType("CELL").operationalCapacity(2).currentOccupancy(1).active(true).profiles(buildAgencyInternalLocationProfiles()).build(),
+                AgencyInternalLocation.builder().locationId(-3L).locationType("CELL").operationalCapacity(2).currentOccupancy(2).active(true).profiles(buildAgencyInternalLocationProfiles()).build()
         ));
-        when(agencyInternalLocationProfileRepository.findAllByLocationId(anyLong())).thenReturn(buildAgencyInternalLocationProfiles());
 
         final var offenderCells = service.getCellsWithCapacityInAgency("LEI", null);
         assertThat(offenderCells).extracting("id").containsExactly(-1L, -2L);
@@ -156,14 +155,11 @@ public class AgencyServiceTest {
 
     @Test
     public void shouldReturnAllActiveCellsWithSpaceForAgencyWithAttribute() {
-        when(agencyInternalLocationRepository.findAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive("LEI", "CELL", true)).thenReturn(List.of(
-                AgencyInternalLocation.builder().locationId(-1L).locationType("CELL").operationalCapacity(2).currentOccupancy(1).active(true).build(),
-                AgencyInternalLocation.builder().locationId(-2L).locationType("CELL").capacity(2).currentOccupancy(1).active(true).build(),
-                AgencyInternalLocation.builder().locationId(-3L).locationType("CELL").operationalCapacity(2).currentOccupancy(2).active(true).build()
+        when(agencyInternalLocationRepository.findWithProfilesAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive("LEI", "CELL", true)).thenReturn(List.of(
+                AgencyInternalLocation.builder().locationId(-1L).locationType("CELL").operationalCapacity(2).currentOccupancy(1).active(true).profiles(buildAgencyInternalLocationProfiles()).build(),
+                AgencyInternalLocation.builder().locationId(-2L).locationType("CELL").capacity(2).currentOccupancy(1).active(true).profiles(List.of()).build(),
+                AgencyInternalLocation.builder().locationId(-3L).locationType("CELL").operationalCapacity(2).currentOccupancy(2).active(true).profiles(List.of()).build()
         ));
-
-        when(agencyInternalLocationProfileRepository.findAllByLocationId(-1L)).thenReturn(buildAgencyInternalLocationProfiles());
-        when(agencyInternalLocationProfileRepository.findAllByLocationId(-2L)).thenReturn(List.of());
 
         final var offenderCells = service.getCellsWithCapacityInAgency("LEI", "DO");
         assertThat(offenderCells).extracting("id").containsExactly(-1L);
@@ -171,12 +167,10 @@ public class AgencyServiceTest {
 
     @Test
     public void shouldReturnAllActiveCellsWithIgnoringZeroOperationalCapacityForAgencyWithAttribute() {
-        when(agencyInternalLocationRepository.findAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive("LEI", "CELL", true)).thenReturn(List.of(
-            AgencyInternalLocation.builder().locationId(-1L).locationType("CELL").operationalCapacity(0).capacity(3).currentOccupancy(2).active(true).build(),
-            AgencyInternalLocation.builder().locationId(-2L).locationType("CELL").operationalCapacity(0).capacity(2).currentOccupancy(2).active(true).build()
+        when(agencyInternalLocationRepository.findWithProfilesAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive("LEI", "CELL", true)).thenReturn(List.of(
+            AgencyInternalLocation.builder().locationId(-1L).locationType("CELL").operationalCapacity(0).capacity(3).currentOccupancy(2).active(true).profiles(buildAgencyInternalLocationProfiles()).build(),
+            AgencyInternalLocation.builder().locationId(-2L).locationType("CELL").operationalCapacity(0).capacity(2).currentOccupancy(2).active(true).profiles(emptyList()).build()
         ));
-
-        when(agencyInternalLocationProfileRepository.findAllByLocationId(-1L)).thenReturn(buildAgencyInternalLocationProfiles());
 
         final var offenderCells = service.getCellsWithCapacityInAgency("LEI", "DO");
         assertThat(offenderCells).extracting("id").containsExactly(-1L);
@@ -193,8 +187,8 @@ public class AgencyServiceTest {
                         .operationalCapacity(2)
                         .currentOccupancy(1)
                         .active(true)
+                        .profiles(buildAgencyInternalLocationProfiles())
                         .build()));
-        when(agencyInternalLocationProfileRepository.findAllByLocationId(anyLong())).thenReturn(buildAgencyInternalLocationProfiles());
 
         final var offenderCell = service.getCellAttributes(-1L);
         assertThat(offenderCell).isEqualTo(


### PR DESCRIPTION
For /agencies/{agencyId?/cellsWithCapacity cell profile attributes are currently loaded via a separate repo call which results in a n + 1 query.

For this endpoint only force a join fetch to reduce to a single SQL call to avoid latency issues when Oracle is move to AWS