### PR TITLE
SDI-779 Remove n + 1 SQL for deprecated GET /api/agencies/prison

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/Address.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/Address.java
@@ -1,18 +1,5 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder.Default;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.JoinColumnOrFormula;
-import org.hibernate.annotations.JoinColumnsOrFormulas;
-import org.hibernate.annotations.JoinFormula;
-import org.hibernate.annotations.NotFound;
-import org.hibernate.annotations.Where;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
@@ -26,9 +13,22 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinColumnsOrFormulas;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.Where;
+
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.hibernate.annotations.NotFoundAction.IGNORE;
 import static uk.gov.justice.hmpps.prison.repository.jpa.model.AddressType.ADDR_TYPE;
@@ -116,12 +116,12 @@ public abstract class Address extends AuditableEntity {
     @OneToMany
     @JoinColumn(name = "ADDRESS_ID")
     @Default
-    private List<AddressUsage> addressUsages = new ArrayList<>();
+    private Set<AddressUsage> addressUsages = new HashSet<>();
 
     @OneToMany(mappedBy = "address", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Where(clause = "OWNER_CLASS = '"+AddressPhone.PHONE_TYPE+"'")
     @Default
-    private List<AddressPhone> phones = new ArrayList<>();
+    private Set<AddressPhone> phones = new HashSet<>();
 
     public void removePhone(final AddressPhone phone) {
         phones.remove(phone);

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyLocation.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyLocation.java
@@ -106,7 +106,7 @@ public class AgencyLocation extends AuditableEntity {
     @OneToMany(mappedBy = "agency", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Where(clause = "OWNER_CLASS = '"+AgencyAddress.ADDR_TYPE+"'")
     @Default
-    private List<AgencyAddress> addresses = new ArrayList<>();
+    private Set<AgencyAddress> addresses = new HashSet<>();
 
     @OneToMany(mappedBy = "agency", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Where(clause = "OWNER_CLASS = '"+AgencyPhone.PHONE_TYPE+"'")

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyLocation.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyLocation.java
@@ -1,5 +1,18 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.model;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedSubgraph;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -11,24 +24,16 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.annotations.JoinColumnsOrFormulas;
 import org.hibernate.annotations.JoinFormula;
-import org.hibernate.type.YesNoConverter;
-import jakarta.persistence.Convert;
 import org.hibernate.annotations.Where;
+import org.hibernate.type.YesNoConverter;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static uk.gov.justice.hmpps.prison.repository.jpa.model.AgencyLocationType.AGY_LOC_TYPE;
 import static uk.gov.justice.hmpps.prison.repository.jpa.model.CourtType.JURISDICTION;
@@ -41,6 +46,18 @@ import static uk.gov.justice.hmpps.prison.repository.jpa.model.CourtType.JURISDI
 @Table(name = "AGENCY_LOCATIONS")
 @ToString(of = {"id", "description"})
 @With
+@NamedEntityGraph(
+    name = "agency-location-with-contact-details",
+    attributeNodes =  { @NamedAttributeNode(value = "addresses", subgraph = "address-phone"), @NamedAttributeNode(value = "phones") },
+    subgraphs = {
+    @NamedSubgraph(
+        name = "address-phone",
+        attributeNodes = {
+            @NamedAttributeNode("phones"), @NamedAttributeNode("addressUsages")
+        }
+    )
+}
+)
 public class AgencyLocation extends AuditableEntity {
 
     public static final String IN = "IN";
@@ -94,7 +111,7 @@ public class AgencyLocation extends AuditableEntity {
     @OneToMany(mappedBy = "agency", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Where(clause = "OWNER_CLASS = '"+AgencyPhone.PHONE_TYPE+"'")
     @Default
-    private List<AgencyPhone> phones = new ArrayList<>();
+    private Set<AgencyPhone> phones = new HashSet<>();
 
     @OneToMany(mappedBy = "agency", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Where(clause = "OWNER_CLASS = '"+AgencyInternetAddress.TYPE+"'")

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/AgencyLocationRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/AgencyLocationRepository.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -16,6 +18,7 @@ public interface AgencyLocationRepository extends JpaRepository<AgencyLocation, 
 
     Optional<AgencyLocation> findByIdAndTypeAndActiveAndDeactivationDateIsNull(String id, AgencyLocationType type, boolean active);
 
+    @EntityGraph(type = EntityGraphType.FETCH, value = "agency-location-with-contact-details")
     List<AgencyLocation> findByTypeAndActiveAndDeactivationDateIsNull(AgencyLocationType type, boolean active);
 
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AddressTransformer.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AddressTransformer.java
@@ -7,6 +7,7 @@ import uk.gov.justice.hmpps.prison.api.model.Telephone;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.Address;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.Phone;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -53,7 +54,7 @@ public class AddressTransformer {
                 .build();
     }
 
-    public static List<Telephone> translatePhones(final List<? extends Phone> phones) {
+    public static List<Telephone> translatePhones(final Collection<? extends Phone> phones) {
         return phones.stream().map(AddressTransformer::translate).collect(toList());
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AddressTransformer.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AddressTransformer.java
@@ -9,14 +9,13 @@ import uk.gov.justice.hmpps.prison.repository.jpa.model.Phone;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
 @Component
 public class AddressTransformer {
 
-    public static List<AddressDto> translate(final List<? extends Address> addresses) {
+    public static List<AddressDto> translate(final Collection<? extends Address> addresses) {
         return addresses.stream().map(AddressTransformer::translate).collect(toList());
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AgencyService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AgencyService.java
@@ -303,7 +303,7 @@ public class AgencyService {
                 .build();
         } else {
             final var primaryAddress = prison.getAddresses().stream()
-                .filter(a -> "Y".equals(a.getPrimaryFlag())).findFirst().orElse(prison.getAddresses().get(0));
+                .filter(a -> "Y".equals(a.getPrimaryFlag())).findFirst().orElse(prison.getAddresses().iterator().next());
 
             final var primaryCountry = primaryAddress.getCountry() != null ? primaryAddress.getCountry().getDescription() : null;
             final var primaryTown = primaryAddress.getCity() != null ? primaryAddress.getCity().getDescription() : null;

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/PersonAddressRepositoryTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/PersonAddressRepositoryTest.java
@@ -50,7 +50,7 @@ public class PersonAddressRepositoryTest {
                                     .city(new City("25343", "Sheffield"))
                                     .startDate(LocalDate.of(2016, 8, 2))
                                     .endDate(null)
-                                    .addressUsages(Collections.emptyList())
+                                    .addressUsages(Collections.emptySet())
                                     .build(),
         PersonAddress.builder()
                                     .addressId(-16L)
@@ -69,7 +69,7 @@ public class PersonAddressRepositoryTest {
                                     .city(null)
                                     .startDate(LocalDate.of(2016, 8, 2))
                                     .endDate(null)
-                                    .addressUsages(Collections.emptyList())
+                                    .addressUsages(Collections.emptySet())
                                     .build());
 
         final var addresses = repository.findAllByPersonId(person.getId());

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderAddressServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderAddressServiceImplTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.prison.service;
 
 
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -117,68 +118,76 @@ public class OffenderAddressServiceImplTest {
 
         verify(offenderBookingRepository).findByOffenderNomsIdAndActive(offenderNo, true);
 
-        assertThat(results).isEqualTo(List.of(
+        // ignore Set order for phone and addresses
+        RecursiveComparisonConfiguration configuration = RecursiveComparisonConfiguration
+            .builder()
+            .withIgnoreCollectionOrder(true)
+            .build();
+
+        assertThat(results)
+            .usingRecursiveFieldByFieldElementComparator(configuration)
+            .isEqualTo(List.of(
                 AddressDto.builder()
-                        .addressType("Home Address")
-                        .noFixedAddress(false)
-                        .primary(true)
-                        .comment(null)
-                        .flat("Flat 1")
-                        .premise("Brook Hamlets")
-                        .street("Mayfield Drive")
-                        .postalCode("B5")
-                        .locality("Nether Edge")
-                        .country("England")
-                        .county("South Yorkshire")
-                        .town("Sheffield")
-                        .startDate(LocalDate.of(2016, 8, 2))
-                        .addressId(-15L)
-                        .phones(List.of(
-                                Telephone.builder()
-                                        .phoneId(-7L)
-                                        .number("0114 2345345")
-                                        .ext("345")
-                                        .type("HOME")
-                                        .build(),
-                                Telephone.builder()
-                                        .phoneId(-8L)
-                                        .number("0114 2345346")
-                                        .ext(null)
-                                        .type("BUS")
-                                        .build()))
-                        .addressUsages(List.of(AddressUsageDto.builder()
-                                        .addressId(-15L)
-                                        .activeFlag(true)
-                                        .addressUsage("HDC")
-                                        .addressUsageDescription("HDC address")
-                                        .build(),
-                                AddressUsageDto.builder()
-                                        .addressId(-15L)
-                                        .activeFlag(true)
-                                        .addressUsage("HDC")
-                                        .addressUsageDescription(null)
-                                        .build()
-                                )
+                    .addressType("Home Address")
+                    .noFixedAddress(false)
+                    .primary(true)
+                    .comment(null)
+                    .flat("Flat 1")
+                    .premise("Brook Hamlets")
+                    .street("Mayfield Drive")
+                    .postalCode("B5")
+                    .locality("Nether Edge")
+                    .country("England")
+                    .county("South Yorkshire")
+                    .town("Sheffield")
+                    .startDate(LocalDate.of(2016, 8, 2))
+                    .addressId(-15L)
+                    .phones(List.of(
+                        Telephone.builder()
+                            .phoneId(-7L)
+                            .number("0114 2345345")
+                            .ext("345")
+                            .type("HOME")
+                            .build(),
+                        Telephone.builder()
+                            .phoneId(-8L)
+                            .number("0114 2345346")
+                            .ext(null)
+                            .type("BUS")
+                            .build()))
+                    .addressUsages(List.of(AddressUsageDto.builder()
+                                .addressId(-15L)
+                                .activeFlag(true)
+                                .addressUsage("HDC")
+                                .addressUsageDescription("HDC address")
+                                .build(),
+                            AddressUsageDto.builder()
+                                .addressId(-15L)
+                                .activeFlag(true)
+                                .addressUsage("HDC")
+                                .addressUsageDescription(null)
+                                .build()
                         )
-                        .build(),
+                    )
+                    .build(),
                 AddressDto.builder()
-                        .addressType("Business Address")
-                        .noFixedAddress(true)
-                        .primary(false)
-                        .comment(null)
-                        .flat(null)
-                        .premise(null)
-                        .street(null)
-                        .postalCode(null)
-                        .country("England")
-                        .county(null)
-                        .town(null)
-                        .startDate(LocalDate.of(2016, 8, 2))
-                        .addressId(-16L)
-                        .phones(List.of())
-                        .addressUsages(List.of())
-                        .build())
-        );
+                    .addressType("Business Address")
+                    .noFixedAddress(true)
+                    .primary(false)
+                    .comment(null)
+                    .flat(null)
+                    .premise(null)
+                    .street(null)
+                    .postalCode(null)
+                    .country("England")
+                    .county(null)
+                    .town(null)
+                    .startDate(LocalDate.of(2016, 8, 2))
+                    .addressId(-16L)
+                    .phones(List.of())
+                    .addressUsages(List.of())
+                    .build()));
+
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderAddressServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderAddressServiceImplTest.java
@@ -24,6 +24,7 @@ import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderBookingRepo
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -73,7 +74,7 @@ public class OffenderAddressServiceImplTest {
                         .city(new City("25343", "Sheffield"))
                         .startDate(LocalDate.of(2016, 8, 2))
                         .endDate(null)
-                    .phones( List.of(
+                    .phones( Set.of(
                         AddressPhone.builder()
                             .phoneId(-7L)
                             .phoneNo("0114 2345345")
@@ -86,7 +87,7 @@ public class OffenderAddressServiceImplTest {
                             .phoneType("BUS")
                             .extNo(null)
                             .build()))
-                        .addressUsages(List.of(
+                        .addressUsages(Set.of(
                                 AddressUsage.builder().active(true).addressUsage("HDC").addressUsageType(new AddressUsageType("HDC", "HDC address")).build(),
                                 AddressUsage.builder().active(true).addressUsage("HDC").build()
                         ))

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/PersonServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/PersonServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.justice.hmpps.prison.repository.jpa.repository.PersonRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -66,7 +67,7 @@ public class PersonServiceTest {
             .county(new County("S.YORKSHIRE", "South Yorkshire"))
             .city(new City("25343", "Sheffield"))
             .startDate(LocalDate.of(2016, 8, 2))
-            .phones(List.of(
+            .phones(Set.of(
                 AddressPhone.builder()
                     .phoneId(-7L)
                     .phoneNo("0114 2345345")
@@ -80,7 +81,7 @@ public class PersonServiceTest {
                     .extNo(null)
                     .build())
             )
-            .addressUsages(List.of(
+            .addressUsages(Set.of(
                 AddressUsage.builder().active(true).addressUsage("HDC").addressUsageType(new AddressUsageType("HDC", "HDC address")).build(),
                 AddressUsage.builder().active(true).addressUsage("HDC").build()
             ))

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/PersonServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/PersonServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.prison.service;
 
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,7 +113,14 @@ public class PersonServiceTest {
 
         List<AddressDto> results = personService.getAddresses(-8L);
 
-        assertThat(results).isEqualTo(List.of(
+        // ignore Set order for phone and addresses
+        RecursiveComparisonConfiguration configuration = RecursiveComparisonConfiguration
+            .builder()
+            .withIgnoreCollectionOrder(true)
+            .build();
+
+        assertThat(results)
+            .usingRecursiveFieldByFieldElementComparator(configuration).isEqualTo(List.of(
             AddressDto.builder()
                 .addressType("Home Address")
                 .noFixedAddress(false)


### PR DESCRIPTION
Currently this version of endpoint is returning prison phones numbers and address and phones numbers for each address.

Each prison has a single address and 2 numbers and each address has the the same 2 numbers. There is around 127 prisons.

Convert the n * 3 + 1  query to a single Cartesian Product join - we can do this because we know there is a "small" number of prisons and each has a single address and 2 numbers.

Phones and Addresses need to become a set else Hibernate can not load addresses and phones at same time. There is only one primary address per prison but the impact of this PR is the phone numbers might be returned in a different order (though no clients even read the phones let alone rely on the order rather than the type)