### PR TITLE
SDI-803 Remove n + 1 SQL for /api/bookings/{bookingId}/visits-with-visitors

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/VisitVisitor.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/VisitVisitor.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.model;
 
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,6 +38,12 @@ import static uk.gov.justice.hmpps.prison.repository.jpa.model.VisitOutcomeReaso
 @RequiredArgsConstructor
 @Entity
 @Table(name = "OFFENDER_VISIT_VISITORS")
+@NamedEntityGraph(
+    name = "visitor-with-person",
+    attributeNodes = {
+        @NamedAttributeNode(value = "person"),
+    }
+)
 public class VisitVisitor extends AuditableEntity {
 
     @SequenceGenerator(name = "OFFENDER_VISIT_VISITOR_ID", sequenceName = "OFFENDER_VISIT_VISITOR_ID", allocationSize = 1)
@@ -82,7 +90,7 @@ public class VisitVisitor extends AuditableEntity {
     @NotFound(action = IGNORE)
     @JoinColumnsOrFormulas(value = {
             @JoinColumnOrFormula(formula = @JoinFormula(value = "'" + VISIT_OUTCOME_REASON + "'", referencedColumnName = "domain")),
-            @JoinColumnOrFormula(column = @JoinColumn(name = "OUTCOME_REASON_CODE", referencedColumnName = "code", nullable = false))
+            @JoinColumnOrFormula(column = @JoinColumn(name = "OUTCOME_REASON_CODE", referencedColumnName = "code"))
     })
     private VisitOutcomeReason outcomeReason;
 
@@ -91,7 +99,7 @@ public class VisitVisitor extends AuditableEntity {
     @NotFound(action = IGNORE)
     @JoinColumnsOrFormulas(value = {
             @JoinColumnOrFormula(formula = @JoinFormula(value = "'" + EVENT_OUTCOME + "'", referencedColumnName = "domain")),
-            @JoinColumnOrFormula(column = @JoinColumn(name = "EVENT_OUTCOME", referencedColumnName = "code", nullable = false))
+            @JoinColumnOrFormula(column = @JoinColumn(name = "EVENT_OUTCOME", referencedColumnName = "code"))
     })
     private EventOutcome eventOutcome;
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderContactPersonsRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderContactPersonsRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface OffenderContactPersonsRepository extends CrudRepository<OffenderContactPerson, Long> {
     List<OffenderContactPerson> findAllByPersonIdAndOffenderBooking_BookingId(final long personId, final long bookingId);
     List<OffenderContactPerson> findAllByOffenderBooking_BookingIdOrderByIdDesc(final long bookingId);
+    List<OffenderContactPerson> findAllByOffenderBooking_BookingIdAndPersonIdIn(final long bookingId, final List<Long> personIds);
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/VisitVisitorRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/VisitVisitorRepository.java
@@ -1,10 +1,13 @@
 package uk.gov.justice.hmpps.prison.repository.jpa.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.repository.CrudRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.VisitVisitor;
 
 import java.util.List;
 
 public interface VisitVisitorRepository extends CrudRepository<VisitVisitor, Long> {
-    List<VisitVisitor> findByVisitId(Long visitId);
+    @EntityGraph(type = EntityGraphType.FETCH, value = "visitor-with-person")
+    List<VisitVisitor> findByVisitIdInAndOffenderBookingIsNullOrderByPerson_BirthDateDesc(List<Long> visitIds);
 }


### PR DESCRIPTION
This currently does an (n * 2) + 1 SQL query, since for each visitor it loads
- The lead visitor contact
- For each visitor
- The person contact
- The person

This service is a mixture of pure JPA and a SQL sub select - to keep the sub-select and to just optimise the visitor/contact part just the later is moved to use our JPA. But that still requires a repo findBy to pass-through a list of person ids or visitids.

It would be preferable to convert the entire endpoint to pure JPA to improve readability 