### PR TITLE
NN-5100 Get OIC Hearing results endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
@@ -78,7 +78,7 @@ public class AdjudicationsResource {
     @ProxyUser
     @PreAuthorize("hasRole('MAINTAIN_ADJUDICATIONS') and hasAuthority('SCOPE_write')")
     public ResponseEntity<AdjudicationDetail> createAdjudication(@Valid @RequestBody @Parameter(description = "Adjudication details to save", required = true) final NewAdjudication adjudicationDetails) {
-        final var savedAdjudication = adjudicationsService.createAdjudication(adjudicationDetails.getOffenderNo(), adjudicationDetails);
+        final var savedAdjudication = adjudicationsService.createAdjudication(adjudicationDetails);
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(savedAdjudication);
@@ -179,6 +179,21 @@ public class AdjudicationsResource {
         @PathVariable("oicHearingId") final Long oicHearingId
     ) {
         adjudicationsService.deleteOicHearing(adjudicationNumber, oicHearingId);
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "A list of ordered hearing results"),
+        @ApiResponse(responseCode = "403", description = "The client is not authorised for this operation"),
+        @ApiResponse(responseCode = "404", description = "No match was found for the adjudication number or hearing", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "Returns hearing results for specified hearing in sequence order", description = "Requires MAINTAIN_ADJUDICATIONS access")
+    @GetMapping("/adjudication/{adjudicationNumber}/hearing/{oicHearingId}/result")
+    @PreAuthorize("hasRole('MAINTAIN_ADJUDICATIONS')")
+    @ResponseStatus(HttpStatus.OK)
+    public List<OicHearingResultDto> getOicHearingResults(
+        @PathVariable("adjudicationNumber") final Long adjudicationNumber,
+        @PathVariable("oicHearingId") final Long oicHearingId) {
+        return adjudicationsService.getOicHearingResults(adjudicationNumber, oicHearingId);
     }
 
     @ApiResponses({

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AdjudicationsResource.java
@@ -78,7 +78,7 @@ public class AdjudicationsResource {
     @ProxyUser
     @PreAuthorize("hasRole('MAINTAIN_ADJUDICATIONS') and hasAuthority('SCOPE_write')")
     public ResponseEntity<AdjudicationDetail> createAdjudication(@Valid @RequestBody @Parameter(description = "Adjudication details to save", required = true) final NewAdjudication adjudicationDetails) {
-        final var savedAdjudication = adjudicationsService.createAdjudication(adjudicationDetails);
+        final var savedAdjudication = adjudicationsService.createAdjudication(adjudicationDetails.getOffenderNo(), adjudicationDetails);
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(savedAdjudication);

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OicHearingResultRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OicHearingResultRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 
 public interface OicHearingResultRepository extends CrudRepository<OicHearingResult, PK> {
     List<OicHearingResult> findByAgencyIncidentIdAndFindingCode(Long agencyIncidentId, FindingCode findingCode);
+
+    List<OicHearingResult> findByOicHearingId(Long oicHearingId);
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AdjudicationsService.java
@@ -148,7 +148,8 @@ public class AdjudicationsService {
 
     @Transactional
     @VerifyOffenderAccess
-    public AdjudicationDetail createAdjudication(@NotNull @Valid final NewAdjudication adjudication) {
+    public AdjudicationDetail createAdjudication(@SuppressWarnings("unused") @NotNull final String offenderNo, // This is to make the `@VerifyOffenderAccess` check access rights
+                                                 @NotNull @Valid final NewAdjudication adjudication) {
         final var currentDateTime = adjudication.getReportedDateTime();
         final var incidentDateTime = adjudication.getIncidentTime();
 

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceIntTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceIntTest.java
@@ -33,7 +33,7 @@ public class AdjudicationsServiceIntTest {
                 .statement(generateMessageWith4001Chars())
                 .build();
 
-            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize.getOffenderNo(), adjudicationWithLargeStatementSize))
+            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessageContaining("Length exceeds the maximum size allowed");
         }
@@ -45,7 +45,7 @@ public class AdjudicationsServiceIntTest {
                 .statement(generateMessageWith4000CharsAndUtf8Chars())
                 .build();
 
-            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize.getOffenderNo(), adjudicationWithLargeStatementSize))
+            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessageContaining("Length exceeds the maximum size allowed");
         }
@@ -57,7 +57,7 @@ public class AdjudicationsServiceIntTest {
                 .statement("A statement")
                 .build();
 
-            assertThatThrownBy(() -> service.createAdjudication("Z1234ZZ", adjudication))
+            assertThatThrownBy(() -> service.createAdjudication(adjudication))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("Resource with id [Z1234ZZ] not found.");
         }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceIntTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceIntTest.java
@@ -50,18 +50,6 @@ public class AdjudicationsServiceIntTest {
                 .hasMessageContaining("Length exceeds the maximum size allowed");
         }
 
-        @Test
-        @WithMockUser(username = "ITAG_USER")
-        public void invalidOffenderNo() {
-            final var adjudication = defaultAdjudicationBuilder()
-                .statement("A statement")
-                .build();
-
-            assertThatThrownBy(() -> service.createAdjudication(adjudication))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("Resource with id [Z1234ZZ] not found.");
-        }
-
         private NewAdjudicationBuilder defaultAdjudicationBuilder() {
             return NewAdjudication.builder()
                 .offenderNo("A1234AD")

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceIntTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceIntTest.java
@@ -33,7 +33,7 @@ public class AdjudicationsServiceIntTest {
                 .statement(generateMessageWith4001Chars())
                 .build();
 
-            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize))
+            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize.getOffenderNo(), adjudicationWithLargeStatementSize))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessageContaining("Length exceeds the maximum size allowed");
         }
@@ -45,9 +45,21 @@ public class AdjudicationsServiceIntTest {
                 .statement(generateMessageWith4000CharsAndUtf8Chars())
                 .build();
 
-            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize))
+            assertThatThrownBy(() -> service.createAdjudication(adjudicationWithLargeStatementSize.getOffenderNo(), adjudicationWithLargeStatementSize))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessageContaining("Length exceeds the maximum size allowed");
+        }
+
+        @Test
+        @WithMockUser(username = "ITAG_USER")
+        public void invalidOffenderNo() {
+            final var adjudication = defaultAdjudicationBuilder()
+                .statement("A statement")
+                .build();
+
+            assertThatThrownBy(() -> service.createAdjudication("Z1234ZZ", adjudication))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Resource with id [Z1234ZZ] not found.");
         }
 
         private NewAdjudicationBuilder defaultAdjudicationBuilder() {

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
@@ -51,7 +51,6 @@ import uk.gov.justice.hmpps.prison.repository.jpa.repository.OicHearingResultRep
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OicSanctionRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.ReferenceCodeRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.StaffUserAccountRepository;
-import uk.gov.justice.hmpps.prison.security.AuthenticationFacade;
 
 import jakarta.persistence.EntityManager;
 import jakarta.validation.ValidationException;
@@ -93,8 +92,6 @@ public class AdjudicationsServiceTest {
     private static final String EXAMPLE_STATEMENT = "Example statement";
     private static final String EXAMPLE_CREATOR_ID = "ASMITH";
     private static final LocalDateTime EXAMPLE_INCIDENT_TIME = LocalDateTime.of(2020, 1, 1, 2, 3, 4);
-    private Integer BATCH_SIZE = 1;
-
     @Mock
     private AdjudicationRepository adjudicationsRepository;
     @Mock
@@ -111,8 +108,6 @@ public class AdjudicationsServiceTest {
     private AgencyLocationRepository agencyLocationRepository;
     @Mock
     private AgencyInternalLocationRepository internalLocationRepository;
-    @Mock
-    private AuthenticationFacade authenticationFacade;
     @Mock
     private TelemetryClient telemetryClient;
     @Mock
@@ -133,6 +128,7 @@ public class AdjudicationsServiceTest {
 
     @BeforeEach
     public void beforeEach() {
+        final var BATCH_SIZE = 1;
         service = new AdjudicationsService(
             adjudicationsRepository,
             offenceTypeRepository,
@@ -142,9 +138,7 @@ public class AdjudicationsServiceTest {
             actionCodeRepository,
             agencyLocationRepository,
             internalLocationRepository,
-            authenticationFacade,
             telemetryClient,
-            clock,
             entityManager,
             BATCH_SIZE,
             adjudicationsPartyService,
@@ -209,7 +203,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
+            service.createAdjudication(newAdjudication);
 
             verify(adjudicationsRepository).save(assertArgThat(actualAdjudication -> {
                     assertThat(actualAdjudication).usingRecursiveComparison().ignoringFields("createUserId", "parties")
@@ -254,7 +248,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            final var returnedAdjudication = service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
+            final var returnedAdjudication = service.createAdjudication(newAdjudication);
 
             assertThat(returnedAdjudication).isEqualTo(expectedReturnedAdjudication);
         }
@@ -276,7 +270,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
+            service.createAdjudication(newAdjudication);
 
             verify(telemetryClient).trackEvent("AdjudicationCreated",
                 Map.of(
@@ -284,7 +278,7 @@ public class AdjudicationsServiceTest {
                     "offenderNo", mockDataProvider.getOffenderNo(),
                     "incidentTime", EXAMPLE_INCIDENT_TIME.toString(),
                     "incidentLocation", mockDataProvider.getIncidentLocation(),
-                    "statementSize", "" + mockDataProvider.getStatement().length()
+                    "statementSize", String.valueOf(mockDataProvider.getStatement().length())
                 ),
                 null);
         }
@@ -302,7 +296,7 @@ public class AdjudicationsServiceTest {
                 mockDataProvider.internalLocation.getLocationId());
 
             assertThatThrownBy(() ->
-                service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication))
+                service.createAdjudication(newAdjudication))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("Agency with id LEI does not exist");
 
@@ -322,7 +316,7 @@ public class AdjudicationsServiceTest {
                 mockDataProvider.internalLocation.getLocationId());
 
             assertThatThrownBy(() ->
-                service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication))
+                service.createAdjudication(newAdjudication))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("Location with id 456 does not exist or is not in your caseload");
 
@@ -350,7 +344,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
+            service.createAdjudication(newAdjudication);
 
             verify(adjudicationsRepository).save(assertArgThat(actualAdjudication -> {
                     assertThat(actualAdjudication).usingRecursiveComparison().ignoringFields("createUserId", "parties")
@@ -394,7 +388,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            final var returnedAdjudication = service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
+            final var returnedAdjudication = service.createAdjudication(newAdjudication);
 
             assertThat(returnedAdjudication).isEqualTo(expectedReturnedAdjudication);
         }
@@ -425,7 +419,7 @@ public class AdjudicationsServiceTest {
 
                 when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-                final var returnedAdjudication = service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
+                final var returnedAdjudication = service.createAdjudication(newAdjudication);
 
                 assertThat(returnedAdjudication.getAdjudicationNumber()).isEqualTo(EXAMPLE_ADJUDICATION_NUMBER);
 
@@ -449,7 +443,7 @@ public class AdjudicationsServiceTest {
                 newAdjudication.setOffenceCodes(List.of(EXAMPLE_OFFENCE_CHARGE_CODE, "51:99"));
 
                 assertThatThrownBy(() ->
-                    service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication))
+                    service.createAdjudication(newAdjudication))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Offence code not found");
             }
@@ -500,10 +494,8 @@ public class AdjudicationsServiceTest {
         public void makesCallToRepositoryWithCorrectData() {
             service.updateAdjudication(updateNumber, updateRequest);
 
-            verify(adjudicationsRepository).save(assertArgThat(actualAdjudication -> {
-                    assertThat(actualAdjudication).usingRecursiveComparison().ignoringFields("parties")
-                        .isEqualTo(savedAdjudication);
-                }
+            verify(adjudicationsRepository).save(assertArgThat(actualAdjudication -> assertThat(actualAdjudication).usingRecursiveComparison().ignoringFields("parties")
+                .isEqualTo(savedAdjudication)
             ));
         }
 
@@ -540,10 +532,10 @@ public class AdjudicationsServiceTest {
 
             verify(telemetryClient).trackEvent("AdjudicationUpdated",
                 Map.of(
-                    "adjudicationNumber", "" + updateNumber,
+                    "adjudicationNumber", String.valueOf(updateNumber),
                     "incidentTime", updatedIncidentTime.toString(),
                     "incidentLocation", updatedInternalLocation.getDescription(),
-                    "statementSize", "" + updatedStatement.length()
+                    "statementSize", String.valueOf(updatedStatement.length())
                 ),
                 null);
         }
@@ -579,10 +571,7 @@ public class AdjudicationsServiceTest {
         private Adjudication savedAdjudication;
         private Long updateNumber;
         private UpdateAdjudication updateRequest;
-        private LocalDateTime updatedIncidentTime;
         private List<String> updatedOffenceCodes;
-        private String updatedStatement;
-        private AgencyInternalLocation updatedInternalLocation;
 
         @BeforeEach
         public void setup() {
@@ -590,17 +579,17 @@ public class AdjudicationsServiceTest {
             existingSavedAdjudication = generateExampleAdjudication_WithOptionalData(new MockDataProvider(), updateNumber);
             when(adjudicationsRepository.findByParties_AdjudicationNumber(updateNumber)).thenReturn(Optional.of(existingSavedAdjudication));
 
-            updatedIncidentTime = LocalDateTime.of(2020, 1, 1, 2, 3, 5);
-            updatedStatement = "New statement";
+            LocalDateTime updatedIncidentTime = LocalDateTime.of(2020, 1, 1, 2, 3, 5);
+            String updatedStatement = "New statement";
 
             updatedOffenceCodes = List.of("51:22", "51:24");
             final var offenderParty = existingSavedAdjudication.getOffenderParty().get();
             final var offenderPartyCharges = generateExampleAdjudicationCharges(offenderParty, updatedOffenceCodes);
             offenderParty.setCharges(offenderPartyCharges);
-            final var offenceTypes = offenderPartyCharges.stream().map(c -> c.getOffenceType()).toList();
+            final var offenceTypes = offenderPartyCharges.stream().map(AdjudicationCharge::getOffenceType).toList();
             lenient().when(offenceTypeRepository.findByOffenceCodeIn(updatedOffenceCodes)).thenReturn(offenceTypes);
 
-            updatedInternalLocation = AgencyInternalLocation.builder()
+            AgencyInternalLocation updatedInternalLocation = AgencyInternalLocation.builder()
                 .locationId(11L)
                 .description("Basketball")
                 .build();
@@ -818,7 +807,7 @@ public class AdjudicationsServiceTest {
     @Nested
     public class AdjudicationHearings {
 
-        private LocalDateTime now  = LocalDateTime.now();
+        private final LocalDateTime now  = LocalDateTime.now();
 
         private final OicHearingRequest oicHearingRequest =
             OicHearingRequest.builder()

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/AdjudicationsServiceTest.java
@@ -203,7 +203,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            service.createAdjudication(newAdjudication);
+            service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
 
             verify(adjudicationsRepository).save(assertArgThat(actualAdjudication -> {
                     assertThat(actualAdjudication).usingRecursiveComparison().ignoringFields("createUserId", "parties")
@@ -248,7 +248,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            final var returnedAdjudication = service.createAdjudication(newAdjudication);
+            final var returnedAdjudication = service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
 
             assertThat(returnedAdjudication).isEqualTo(expectedReturnedAdjudication);
         }
@@ -270,7 +270,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            service.createAdjudication(newAdjudication);
+            service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
 
             verify(telemetryClient).trackEvent("AdjudicationCreated",
                 Map.of(
@@ -296,7 +296,7 @@ public class AdjudicationsServiceTest {
                 mockDataProvider.internalLocation.getLocationId());
 
             assertThatThrownBy(() ->
-                service.createAdjudication(newAdjudication))
+                service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("Agency with id LEI does not exist");
 
@@ -316,7 +316,7 @@ public class AdjudicationsServiceTest {
                 mockDataProvider.internalLocation.getLocationId());
 
             assertThatThrownBy(() ->
-                service.createAdjudication(newAdjudication))
+                service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("Location with id 456 does not exist or is not in your caseload");
 
@@ -344,7 +344,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            service.createAdjudication(newAdjudication);
+            service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
 
             verify(adjudicationsRepository).save(assertArgThat(actualAdjudication -> {
                     assertThat(actualAdjudication).usingRecursiveComparison().ignoringFields("createUserId", "parties")
@@ -388,7 +388,7 @@ public class AdjudicationsServiceTest {
 
             when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-            final var returnedAdjudication = service.createAdjudication(newAdjudication);
+            final var returnedAdjudication = service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
 
             assertThat(returnedAdjudication).isEqualTo(expectedReturnedAdjudication);
         }
@@ -419,7 +419,7 @@ public class AdjudicationsServiceTest {
 
                 when(adjudicationsRepository.findByParties_AdjudicationNumber(any())).thenReturn(Optional.empty(), Optional.of(expectedAdjudication));
 
-                final var returnedAdjudication = service.createAdjudication(newAdjudication);
+                final var returnedAdjudication = service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication);
 
                 assertThat(returnedAdjudication.getAdjudicationNumber()).isEqualTo(EXAMPLE_ADJUDICATION_NUMBER);
 
@@ -443,7 +443,7 @@ public class AdjudicationsServiceTest {
                 newAdjudication.setOffenceCodes(List.of(EXAMPLE_OFFENCE_CHARGE_CODE, "51:99"));
 
                 assertThatThrownBy(() ->
-                    service.createAdjudication(newAdjudication))
+                    service.createAdjudication(newAdjudication.getOffenderNo(), newAdjudication))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Offence code not found");
             }


### PR DESCRIPTION
Allows adj api to check if an hearing results has been added in NOMIS - in this instance will then lock down the report in the DPS service as its basically clobbered.