### PR TITLE
SDI-805 remove n + 1 query for transaction use batch size

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderTransactionHistory.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderTransactionHistory.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -88,6 +89,7 @@ public class OffenderTransactionHistory {
     })
     @OneToMany
     @Default
+    @BatchSize(size = 1000)
     private List<OffenderTransactionDetails> relatedTransactionDetails = new ArrayList<>();
 
     @Builder.Default

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderTransactionHistoryServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderTransactionHistoryServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.prison.service;
 
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,11 +37,14 @@ public class OffenderTransactionHistoryServiceTest {
     @Mock
     private OffenderTransactionHistoryRepository repository;
 
+    @Mock
+    private EntityManager entityManager;
+
     private OffenderTransactionHistoryService service;
 
     @BeforeEach
     public void setUp() {
-        service = new OffenderTransactionHistoryService("GBP", repository);
+        service = new OffenderTransactionHistoryService("GBP", repository, entityManager);
     }
 
     final Offender OFFENDER = Offender.builder().nomsId(OFFENDER_NO).rootOffenderId(2L).id(3L).build();


### PR DESCRIPTION
There is n + 1 SQL for transaction history due to the 1 to many relationship for transaction details .

Solution:

1. Add batch to @BatchSize relatedTransactionDetails to use `IN` query rather than multiple individual selects
2. Also ensure only the filtered transactions are used in the `IN` query by evicting redundant transaction from Hibernate cache