### PR TITLE
HIA-360 Add active field to ImageDetail response model

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/ImageDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/ImageDetail.java
@@ -32,6 +32,10 @@ public class ImageDetail {
     @NotNull
     private Long imageId;
 
+    @Schema(requiredMode = RequiredMode.REQUIRED, description = "Active", example = "false")
+    @NotNull
+    private Boolean active;
+
     @Schema(requiredMode = RequiredMode.REQUIRED, description = "Date of image capture", example = "2008-08-27")
     @NotNull
     private LocalDate captureDate;

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderImage.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderImage.java
@@ -83,6 +83,7 @@ public class OffenderImage extends AuditableEntity {
     public ImageDetail transform() {
         return ImageDetail.builder()
             .imageId(getId())
+            .active(isActive())
             .captureDate(getCaptureDateTime().toLocalDate())
             .imageView(getViewType())
             .imageOrientation(getOrientationType())

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/ImageServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/ImageServiceImplTest.java
@@ -51,6 +51,7 @@ public class ImageServiceImplTest {
         when(offenderImageRepository.getImagesByOffenderNumber(OFFENDER_NUMBER)).thenReturn(List.of(
                 OffenderImage.builder()
                         .id(123L)
+                        .active(false)
                         .captureDateTime(DATETIME)
                         .viewType("FACE")
                         .orientationType("FRONT")
@@ -61,6 +62,7 @@ public class ImageServiceImplTest {
         assertThat(service.findOffenderImagesFor(OFFENDER_NUMBER)).containsOnly(
                 ImageDetail.builder()
                         .imageId(123L)
+                        .active(false)
                         .captureDate(DATETIME.toLocalDate())
                         .imageView("FACE")
                         .imageOrientation("FRONT")

--- a/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/getimagesbyoffender.json
+++ b/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/getimagesbyoffender.json
@@ -1,6 +1,7 @@
 [
   {
     "imageId":-1,
+    "active": true,
     "captureDate":"2008-08-27",
     "imageView":"FACE",
     "imageOrientation":"FRONT",


### PR DESCRIPTION
Expose `active` field to allow clients to select the most relevant images.