### PR TITLE
HIA-360 Add active captureDateTime to ImageDetail response model

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/ImageDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/ImageDetail.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * Image Detail
@@ -35,6 +36,10 @@ public class ImageDetail {
     @Schema(requiredMode = RequiredMode.REQUIRED, description = "Date of image capture", example = "2008-08-27")
     @NotNull
     private LocalDate captureDate;
+
+    @Schema(requiredMode = RequiredMode.REQUIRED, description = "Date and time of image capture", example = "2008-08-28T01:01:01")
+    @NotNull
+    private LocalDateTime captureDateTime;
 
     @Schema(requiredMode = RequiredMode.REQUIRED,
         description = "Image view information.  Actual values extracted 10/05/2023, with the majority of values being FACE. This doesn't appear to be mapped to any REFERENCE_CODE data, even though there is a domain called IMAGE_VIEW.",

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderImage.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderImage.java
@@ -84,6 +84,7 @@ public class OffenderImage extends AuditableEntity {
         return ImageDetail.builder()
             .imageId(getId())
             .captureDate(getCaptureDateTime().toLocalDate())
+            .captureDateTime(getCaptureDateTime())
             .imageView(getViewType())
             .imageOrientation(getOrientationType())
             .imageType(getImageType())

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/ImageServiceImplTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/ImageServiceImplTest.java
@@ -62,6 +62,7 @@ public class ImageServiceImplTest {
                 ImageDetail.builder()
                         .imageId(123L)
                         .captureDate(DATETIME.toLocalDate())
+                        .captureDateTime(DATETIME)
                         .imageView("FACE")
                         .imageOrientation("FRONT")
                         .imageType("OFF_BKG")

--- a/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/getimagesbyoffender.json
+++ b/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/getimagesbyoffender.json
@@ -2,6 +2,7 @@
   {
     "imageId":-1,
     "captureDate":"2008-08-27",
+    "captureDateTime":"2008-08-27T00:00:00",
     "imageView":"FACE",
     "imageOrientation":"FRONT",
     "imageType":"OFF_BKG"


### PR DESCRIPTION
The captureDate property of `ImageDetail` doesn't contain the time. This PR adds a new property `captureDateTime` to expose add the time to the image detail endpoints.

These changes were based on the changes made by @emileswarts in [this PR](https://github.com/ministryofjustice/prison-api/pull/1594). As our team now has permissions to branch and PR on Prison API. We've redone the changes.