### PR TITLE
HIA-292: Fix incorrect Swagger documentation for sentence terms endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderSentenceResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderSentenceResource.java
@@ -194,7 +194,7 @@ public class OffenderSentenceResource {
     }
 
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Sentence term details for a prisoner.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = OffenderSentenceTerms.class))}),
+            @ApiResponse(responseCode = "200", description = "Sentence term details for a prisoner."),
             @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @Operation(summary = "Sentence term details for a prisoner")
     @GetMapping("/booking/{bookingId}/sentenceTerms")


### PR DESCRIPTION
## Context

The 200 response for the `GET /api/offender-sentences/booking/{bookingId}/sentenceTerms` endpoint incorrectly documented that the response body is a single JSON object instead of a list of objects, see [/api/offender-sentences/booking/{bookingId}/sentenceTerms](https://api-dev.prison.service.justice.gov.uk/swagger-ui/index.html#/offender-sentences/getOffenderSentenceTerms) in dev.

## Changes proposed in this PR

Let the Swagger annotation document the response body from the return type of the controller method for the API endpoint in order to document it being a list of objects.

Before | After
-- | --
![image](https://github.com/ministryofjustice/prison-api/assets/42817036/27187b81-eb0f-4c45-b0b1-029c0edb03c5) |  ![image](https://github.com/ministryofjustice/prison-api/assets/42817036/5fa60689-60cf-4783-b79e-88c04b23551c)


</figure>