### PR TITLE
Add examples of offender sentence terms to OpenAPI spec

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderSentenceTerm.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderSentenceTerm.java
@@ -14,16 +14,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class OffenderSentenceTerm {
-    @Schema(description = "The term duration - years")
+    @Schema(description = "The term duration - years", example = "1")
     private Integer years;
 
-    @Schema(description = "The term duration - months")
+    @Schema(description = "The term duration - months", example = "2")
     private Integer months;
 
-    @Schema(description = "The term duration - weeks")
+    @Schema(description = "The term duration - weeks", example = "3")
     private Integer weeks;
 
-    @Schema(description = "The term duration - days")
+    @Schema(description = "The term duration - days", example = "4")
     private Integer days;
 
     @Schema(description = "The sentence term code, indicating if this is the term of imprisonment or license")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderSentenceTerms.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderSentenceTerms.java
@@ -38,16 +38,16 @@ public class OffenderSentenceTerms {
     @Schema(description = "Start date of sentence term.", example = "2018-12-31")
     private LocalDate startDate;
 
-    @Schema(description = "Sentence length years.")
+    @Schema(description = "Sentence length years.", example = "1")
     private Integer years;
 
-    @Schema(description = "Sentence length months.")
+    @Schema(description = "Sentence length months.", example = "2")
     private Integer months;
 
-    @Schema(description = "Sentence length weeks.")
+    @Schema(description = "Sentence length weeks.", example = "3")
     private Integer weeks;
 
-    @Schema(description = "Sentence length days.")
+    @Schema(description = "Sentence length days.", example = "4")
     private Integer days;
 
     @Schema(description = "Whether this is a life sentence.")


### PR DESCRIPTION
Adding examples makes it possible to quickly create simulators based on only the OpenAPI specification for services that depend on the Prison API. The HMPPS Integration API relies on this style of testing made possible by a tool called Prism.