### PR TITLE
CRS-1365 amend prison api to add all known releasedates

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/calculation/CalculableSentenceEnvelope.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/calculation/CalculableSentenceEnvelope.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.hmpps.prison.api.model.BookingAdjustment
 import uk.gov.justice.hmpps.prison.api.model.FixedTermRecallDetails
 import uk.gov.justice.hmpps.prison.api.model.OffenderFinePaymentDto
 import uk.gov.justice.hmpps.prison.api.model.SentenceAdjustmentValues
+import uk.gov.justice.hmpps.prison.api.model.SentenceCalcDates
 import uk.gov.justice.hmpps.prison.api.model.SentenceSummary
 
 @Schema(description = "The active sentence envelope is a combination of the person information, the active booking and calculable sentences at a particular establishment")
@@ -26,4 +27,8 @@ data class CalculableSentenceEnvelope(
 
   @Schema(description = "Fixed term recall details")
   val fixedTermRecallDetails: FixedTermRecallDetails? = null,
+
+  @Schema(description = "The current set of sentence dates determined by NOMIS or recorded via overrides")
+  val sentenceCalcDates: SentenceCalcDates? = null,
+
 )

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/SentenceCalcType.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/SentenceCalcType.java
@@ -21,7 +21,7 @@ import java.util.Set;
 @Entity
 @Builder
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper=false)
 @AllArgsConstructor
 @Table(name = "SENTENCE_CALC_TYPES")
 @IdClass(SentenceCalcType.PK.class)

--- a/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/prison_resource_single_calculable_sentence_envelope.json
+++ b/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/prison_resource_single_calculable_sentence_envelope.json
@@ -1,7 +1,7 @@
 {
     "person": {
-        "dateOfBirth": "1966-01-01",
-        "prisonerNumber": "Z0020ZZ"
+        "prisonerNumber": "Z0020ZZ",
+        "dateOfBirth": "1966-01-01"
     },
     "latestPrisonTerm": {
         "bookNumber": "Z00020",
@@ -123,5 +123,18 @@
     "sentenceAdjustments": [],
     "bookingAdjustments": [],
     "offenderFinePayments": [],
-    "fixedTermRecallDetails": null
+    "fixedTermRecallDetails": null,
+    "sentenceCalcDates": {
+        "sentenceExpiryDate": "2020-03-27",
+        "conditionalReleaseDate": "2019-03-24",
+        "actualParoleDate": "2018-09-27",
+        "bookingId": -20,
+        "sentenceStartDate": "2017-03-25",
+        "conditionalReleaseOverrideDate": "2019-03-25",
+        "nonDtoReleaseDate": "2019-03-25",
+        "sentenceExpiryCalculatedDate": "2020-03-24",
+        "sentenceExpiryOverrideDate": "2020-03-27",
+        "nonDtoReleaseDateType": "CRD",
+        "releaseDate": "2018-09-27"
+    }
 }


### PR DESCRIPTION
Minor amendment to include the currently calculated (NOMIS) and user-overridden dates for the current booking. This will help in determining release in errors within a systemic comparison with the Calculate Release Dates Service