### PR TITLE
SDIT-1120 Change override roles when viewing assesments to allow removal of SYSTEM_USER role

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/InmateService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/InmateService.java
@@ -461,7 +461,7 @@ public class InmateService {
                                                         final boolean mostRecentOnly) {
         final List<Assessment> results = new ArrayList<>();
         if (!CollectionUtils.isEmpty(offenderNos)) {
-            final Set<String> caseLoadIds = authenticationFacade.isOverrideRole( "SYSTEM_USER")
+            final Set<String> caseLoadIds = authenticationFacade.isOverrideRole("VIEW_ASSESSMENTS", "VIEW_PRISONER_DATA")
                     ? Collections.emptySet()
                     : caseLoadService.getCaseLoadIdsForUser(authenticationFacade.getCurrentUsername(), false);
 


### PR DESCRIPTION
To allow this change to work correctly, the following clients that have SYSTEM_USER and call this endpoint need updating:

categorisation-tool -> needs VIEW_ASSESSMENTS OR VIEW_PRISONER_DATA role
manage-pom-cases-api  -> already has VIEW_PRISONER_DATA (dev/preprod) role - but needs the role in PROD
manage-soc-cases-admin  -> already has VIEW_PRISONER_DATA role (dev/preprod)- but needs the role in PROD

The following clients call this endpoint but do not need updating:
pathfinder-admin -> already has VIEW_PRISONER_DATA role - no change
prison-staff-hub -> does not have SYSTEM_USER _ROLE - no change























































































































































