### PR TITLE
SDIT-1120 Remove deprecated SYSTEM_USER role in favour of existing VIEW_PRISONER_DATA when viewing booking summary

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingResource.java
@@ -158,7 +158,7 @@ public class BookingResource {
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @Operation(summary = "Prisoners Booking Summary ", description = "Returns data that is available to the users caseload privileges, at least one attribute of a prisonId, bookingId or offenderNo must be specified")
     @GetMapping("/v2")
-    @VerifyBookingAccess(overrideRoles = {"SYSTEM_USER", "VIEW_PRISONER_DATA"})
+    @VerifyBookingAccess(overrideRoles = {"VIEW_PRISONER_DATA"})
     public Page<PrisonerBookingSummary> getPrisonerBookingsV2(
         @RequestParam(value = "prisonId", required = false) @Parameter(description = "Filter by prison Id", example = "MDI") final String prisonId,
         @RequestParam(value = "bookingId", required = false) @Parameter(description = "Filter by a list of booking ids") final List<Long> bookingIds,

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -1144,7 +1144,7 @@ public class BookingService {
             throw new BadRequestException("At least one attribute of a prisonId, bookingId or offenderNo must be specified");
         }
 
-        final var viewAllPrisoners = authenticationFacade.isOverrideRole("SYSTEM_USER", "VIEW_PRISONER_DATA");
+        final var viewAllPrisoners = authenticationFacade.isOverrideRole("VIEW_PRISONER_DATA");
 
         final var filter = OffenderBookingFilter
             .builder()


### PR DESCRIPTION
This endpoint is called by 7 clients
No changes are required for the following:
  create-and-vary-a-licence-admin - does not have SYSTEM_USER role
  keyworker-api - has VIEW_PRISONER_DATA role
  manage-key-workers - does not have SYSTEM_USER role
  prison-staff-hub - does not have SYSTEM_USER role
  visits-orchestration-service- has VIEW_PRISONER_DATA role

Changes required for clients - NEEDS VIEW_PRISONER_DATA role : 
  manage-prison-visits-client
  offender-risk-profiler
