### PR TITLE
SDIT-1120 Only allow inactive bookings for clients with INACTIVE_BOOKINGS role

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -1098,7 +1098,7 @@ public class BookingService {
     }
 
     private boolean isViewInactiveBookings() {
-        return authenticationFacade.isOverrideRole("INACTIVE_BOOKINGS", "SYSTEM_USER");
+        return authenticationFacade.isOverrideRole("INACTIVE_BOOKINGS");
     }
 
     private static String quotedAndPipeDelimited(final Stream<String> values) {


### PR DESCRIPTION
Removing the SYSTEM_USER role means all clients calling this endpoint with the SYSTEM_USER role now require the INACTIVE_BOOKINGS role.
Those not requiring change (Do not currently have SYSTEM_USER role):
book-video-link-client
create-and-vary-a-licence-admin
prison-staff-hub
licences-cloudplatform
manage-key-workers

Those requiring role to be added:
categorisation-tool
licencesadmin-cloud-platform
manage-pom-cases-api

