### PR TITLE
CRS-1500 added get calculable sentence envelope by offender nos

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingResource.java
@@ -84,6 +84,7 @@ import uk.gov.justice.hmpps.prison.api.model.VisitDetails;
 import uk.gov.justice.hmpps.prison.api.model.VisitSummary;
 import uk.gov.justice.hmpps.prison.api.model.VisitWithVisitors;
 import uk.gov.justice.hmpps.prison.api.model.adjudications.AdjudicationSummary;
+import uk.gov.justice.hmpps.prison.api.model.calculation.CalculableSentenceEnvelope;
 import uk.gov.justice.hmpps.prison.api.support.Order;
 import uk.gov.justice.hmpps.prison.core.HasWriteScope;
 import uk.gov.justice.hmpps.prison.core.ProxyUser;
@@ -1227,4 +1228,18 @@ public class BookingResource {
     public List<CourtEventOutcome> getCourtEventOutcomes(@RequestBody @Parameter(description = "The booking ids", required = true) final Set<Long> bookingIds) {
         return bookingService.getOffenderCourtEventOutcomes(bookingIds);
     }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "Details of the active sentence envelope, a combination of the person information, the active booking and calculable sentences for offenders")
+    @PreAuthorize("hasRole('RELEASE_DATE_MANUAL_COMPARER')")
+    @GetMapping("/latest/calculable-sentence-envelope")
+    public List<CalculableSentenceEnvelope> getCalculableSentenceEnvelopeByOffenderNos(@RequestParam(value = "offenderNo") @Parameter(description = "Filter by a list of offender numbers") final Set<String> offenderNumbers) {
+        return bookingService.getCalculableSentenceEnvelopeByOffenderNumbers(offenderNumbers);
+    }
+
+
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
@@ -16,6 +16,7 @@ import uk.gov.justice.hmpps.prison.repository.jpa.model.SentenceCalcType;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface OffenderBookingRepository extends
@@ -38,6 +39,12 @@ public interface OffenderBookingRepository extends
        AgencyLocation agencyLocation,
        List<SentenceCalcType> validCalcTypes
        );
+
+    @EntityGraph(type = EntityGraphType.FETCH, value = "booking-with-sentence-summary")
+    List<OffenderBooking> findAllOffenderBookingsByActiveTrueAndOffenderNomsIdInAndSentences_CalculationTypeIsIn(
+        Set<String> nomsIds,
+        List<SentenceCalcType> validCalcTypes
+    );
 
     Optional<OffenderBooking> findByBookingId(Long bookingId);
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -868,6 +868,19 @@ public class BookingService {
         return activeBookings.stream().map(this::determineCalculableSentenceEnvelope).toList();
     }
 
+    public List<CalculableSentenceEnvelope> getCalculableSentenceEnvelopeByOffenderNumbers(Set<String> offenderNumbers) {
+        final var validCalcTypes = sentenceCalcTypeRepository.findByCalculationTypeNotContainingAndCategoryIsNot(
+            "AGG",
+            "LICENCE"
+        );
+
+        final var activeBookings = offenderBookingRepository.findAllOffenderBookingsByActiveTrueAndOffenderNomsIdInAndSentences_CalculationTypeIsIn(
+            offenderNumbers,
+            validCalcTypes
+        );
+        return activeBookings.stream().map(this::determineCalculableSentenceEnvelope).toList();
+    }
+
     public List<CourtEventOutcome> getOffenderCourtEventOutcomes(final Set<Long> bookingIds) {
         final var courtEvents = courtEventRepository.findByOffenderBooking_BookingIdInAndOffenderCourtCase_CaseStatus_Code(bookingIds, "A");
         return courtEvents.stream().map(event -> new CourtEventOutcome(event.getOffenderBooking().getBookingId(), event.getId(), event.getOutcomeReasonCode() != null ? event.getOutcomeReasonCode().getCode() : null)).toList();

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
@@ -1,0 +1,73 @@
+@file:Suppress("ClassName")
+
+package uk.gov.justice.hmpps.prison.api.resource.impl
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.MediaType
+import uk.gov.justice.hmpps.prison.api.model.calculation.CalculableSentenceEnvelope
+
+class BookingResourceIntTest_getCalculableSentenceEnvelope : ResourceTest() {
+
+  @Autowired
+  val objectMapper = jacksonObjectMapper()
+
+  @Test
+  fun `Test that endpoint returns a summary list when authorised`() {
+    val json = getPrisonResourceAsText("prison_resource_single_calculable_sentence_envelope.json")
+    val calculableSentenceEnvelope = objectMapper.readValue<CalculableSentenceEnvelope>(json)
+
+    val fixedRecallCalculableSentenceEnvelope = objectMapper.readValue<CalculableSentenceEnvelope>(getPrisonResourceAsText("prison_resource_fixed_recall_calculable_sentence_envelope.json"))
+
+    webTestClient.get()
+
+
+      .uri { uriBuilder ->
+        uriBuilder.path("/api/bookings/latest/calculable-sentence-envelope")
+          .queryParam("offenderNo", "Z0020ZZ", "A1234AE")
+          .build()
+      }
+      .headers(
+        setAuthorisation(
+          listOf("ROLE_RELEASE_DATE_MANUAL_COMPARER"),
+        ),
+      )
+      .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBodyList(object : ParameterizedTypeReference<CalculableSentenceEnvelope>() {})
+      .contains(calculableSentenceEnvelope, fixedRecallCalculableSentenceEnvelope)
+  }
+
+  @Test
+  fun `Test that endpoint returns a forbidden when unauthorised`() {
+    webTestClient.get()
+      .uri { uriBuilder ->
+        uriBuilder.path("/api/bookings/latest/calculable-sentence-envelope")
+          .queryParam("offenderNo", "Z0020ZZ", "A1234AE")
+          .build()
+      }
+      .headers(
+        setAuthorisation(
+          listOf("ROLE_RELEASE_DATES_CALCULATOR"),
+        ),
+      )
+      .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  private fun getPrisonResourceAsText(path: String): String {
+    return getResourceAsText("/${this.javaClass.`package`.name.replace(".", "/")}/$path")
+  }
+
+  @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+  private fun getResourceAsText(path: String): String {
+    return object {}.javaClass.getResource(path).readText()
+  }
+}

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
@@ -2,6 +2,7 @@
 
 package uk.gov.justice.hmpps.prison.api.resource.impl
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Test
@@ -13,7 +14,7 @@ import uk.gov.justice.hmpps.prison.api.model.calculation.CalculableSentenceEnvel
 class BookingResourceIntTest_getCalculableSentenceEnvelope : ResourceTest() {
 
   @Autowired
-  val objectMapper = jacksonObjectMapper()
+  lateinit var objectMapper: ObjectMapper
 
   @Test
   fun `Test that endpoint returns a summary list when authorised`() {

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
@@ -23,8 +23,6 @@ class BookingResourceIntTest_getCalculableSentenceEnvelope : ResourceTest() {
     val fixedRecallCalculableSentenceEnvelope = objectMapper.readValue<CalculableSentenceEnvelope>(getPrisonResourceAsText("prison_resource_fixed_recall_calculable_sentence_envelope.json"))
 
     webTestClient.get()
-
-
       .uri { uriBuilder ->
         uriBuilder.path("/api/bookings/latest/calculable-sentence-envelope")
           .queryParam("offenderNo", "Z0020ZZ", "A1234AE")

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest_getCalculableSentenceEnvelope.kt
@@ -3,7 +3,6 @@
 package uk.gov.justice.hmpps.prison.api.resource.impl
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
This is the second way a bulk calculate release dates comparison happens. This is modelled the same as https://github.com/ministryofjustice/prison-api/blob/main/src/main/java/uk/gov/justice/hmpps/prison/api/resource/PrisonResource.kt#L47 but retrieving active bookings by a set of offender numbers instead of establishment id