### PR TITLE
SDIT-548 Allow for missing comments

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/ReleasePrisonerService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/ReleasePrisonerService.kt
@@ -38,7 +38,7 @@ class ReleasePrisonerService(
       request.movementReasonCode,
       booking,
       toLocation,
-      request.commentText,
+      request.commentText ?: "",
     )
 
     return booking

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceIntTest_release.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/OffenderResourceIntTest_release.kt
@@ -448,6 +448,17 @@ class OffenderResourceIntTest_release : ResourceTest() {
             assertThat(it.endDate).isNull()
           }
       }
+
+      @Test
+      fun `should allow missing comment text`() {
+        releaseOffender(offenderNo, releaseRequestWithoutComment())
+          .isOk
+
+        testDataContext.getOffenderBooking(bookingId!!)?.also {
+          assertThat(it.isActive).isFalse()
+          assertThat(it.location.id).isEqualTo("OUT")
+        }
+      }
     }
 
     private fun getOffender(offenderNo: String): StatusAssertions =
@@ -522,6 +533,20 @@ class OffenderResourceIntTest_release : ResourceTest() {
            "movementReasonCode": "$movementReasonCode", 
            "releaseTime": "${releaseTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}",
            "commentText": "released prisoner",
+           "toLocationCode": "$toLocationCode" 
+        }
+      """.trimIndent()
+
+    private fun releaseRequestWithoutComment(
+      movementReasonCode: String = "CR",
+      releaseTime: LocalDateTime = LocalDateTime.now(),
+      toLocationCode: String = "OUT",
+    ): String =
+      """
+        {
+           "movementReasonCode": "$movementReasonCode", 
+           "releaseTime": "${releaseTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}",
+           "commentText": null,
            "toLocationCode": "$toLocationCode" 
         }
       """.trimIndent()


### PR DESCRIPTION
Turns out we [have lots of calls failing on T3](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fc27cfedb-f5e9-45e6-9642-0fad1a5c94e7%2FresourceGroups%2Fnomisapi-t3-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-t3/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAytKLSxNLS4p5qpRKM9ILUpVSM7JL02JD8rPSfVLzE1VsLVVUC8oyizOz9NNLMhUhyvLg0oqBYSGKOgDpfTz09JS81JSi4r1q2FMv%252Fxa%252FaLUnNTE4lQlAI%252B6CzJpAAAA/timespan/P1D) because they don't send comments in the request.