### PR TITLE
SDIT-1268 Remove SYSTEM_USER access from GET /api/staff/roles/{agencyId}/role/{role}

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/StaffService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/StaffService.java
@@ -88,7 +88,7 @@ public class StaffService {
         }
     }
 
-    @VerifyAgencyAccess(overrideRoles = {"SYSTEM_USER", "STAFF_SEARCH"})
+    @VerifyAgencyAccess(overrideRoles = {"STAFF_SEARCH"})
     public Page<StaffLocationRole> getStaffByAgencyPositionRole(final GetStaffRoleRequest request, final PageRequest pageRequest) {
         Validate.notNull(request, "Staff role request details are required.");
         Validate.notNull(pageRequest, "Page request details are required.");

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/StaffResourceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/StaffResourceIntTest.kt
@@ -154,20 +154,10 @@ class StaffResourceIntTest : ResourceTest() {
     fun `should return not found if agency does not exist`() {
       webTestClient.get()
         .uri("/api/staff/roles/XYZ/role/KW")
-        .headers(setClientAuthorisation(listOf("SYSTEM_USER")))
+        .headers(setClientAuthorisation(listOf("STAFF_SEARCH")))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus().isNotFound
-    }
-
-    @Test
-    fun `should return success if has SYSTEM_USER override role`() {
-      webTestClient.get()
-        .uri("/api/staff/roles/BMI/role/KW")
-        .headers(setClientAuthorisation(listOf("SYSTEM_USER")))
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus().isOk
     }
 
     @Test


### PR DESCRIPTION
Added STAFF_SEARCH to 
1. **manage-pom-cases-api** 
2. **offender-management-allocation-manager**
3. **welcome-people-into-prison-client** 

**keyworker-api** already had the role
**manage-key-workers** did not have SYSTEM_USER (so did not need the alternative role)