### PR TITLE
SDIT-1281 Remove SYSTEM_USER from GET /api/prisoners/{offenderNo}

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/GlobalSearchService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/GlobalSearchService.java
@@ -42,7 +42,7 @@ public class GlobalSearchService {
         this.prisonerRepository = prisonerRepository;
     }
 
-    @VerifyOffenderAccess(overrideRoles = {"SYSTEM_USER", "VIEW_PRISONER_DATA"})
+    @VerifyOffenderAccess(overrideRoles = {"VIEW_PRISONER_DATA"})
     public Page<PrisonerDetail> findOffender(final String offenderNo, final PageRequest pageRequest) {
         val criteria = PrisonerDetailSearchCriteria.builder()
             .offenderNos(List.of(offenderNo))


### PR DESCRIPTION
All associated clients either have both SYSTEM_USER and VIEW_PRISONER_DATA or do not have SYSTEM_USER - SYSTEM_USER can therefore be removed from the endpoint