### PR TITLE
SDIT-1288 Remove SYSTEM_USER from activies and properties endpoints

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -312,7 +312,7 @@ public class BookingService {
         return alerts;
     }
 
-    @VerifyBookingAccess(overrideRoles = {"SYSTEM_USER", "VIEW_SCHEDULES"})
+    @VerifyBookingAccess(overrideRoles = {"VIEW_SCHEDULES"})
     public uk.gov.justice.hmpps.prison.api.support.Page<ScheduledEvent> getBookingActivities(final Long bookingId, final LocalDate fromDate, final LocalDate toDate, final long offset, final long limit, final String orderByFields, final Order order) {
         validateScheduledEventsRequest(fromDate, toDate);
 
@@ -795,7 +795,7 @@ public class BookingService {
                 .orElseThrow(EntityNotFoundException.withMessage("Offender booking with id %d not found.", bookingId));
     }
 
-    @VerifyBookingAccess(overrideRoles = {"SYSTEM_USER", "VIEW_PRISONER_DATA"})
+    @VerifyBookingAccess(overrideRoles = {"VIEW_PRISONER_DATA"})
     public List<PropertyContainer> getOffenderPropertyContainers(final Long bookingId) {
         return offenderBookingRepository.findById(bookingId)
                 .map(OffenderBooking::getActivePropertyContainers)

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest.kt
@@ -1145,18 +1145,18 @@ class BookingResourceIntTest : ResourceTest() {
     @Test
     fun `returns 404 for client if booking not found`() {
       webTestClient.get().uri("/api/bookings/-99999/activities")
-        .headers(setClientAuthorisation(listOf("ROLE_SYSTEM_USER")))
+        .headers(setClientAuthorisation(listOf("ROLE_VIEW_SCHEDULES")))
         .exchange()
         .expectStatus().isNotFound
         .expectBody().jsonPath("userMessage").isEqualTo("Offender booking with id -99999 not found.")
     }
 
     @Test
-    fun `returns 200 when client has override role ROLE_SYSTEM_USER`() {
+    fun `returns 403 when client has override role ROLE_SYSTEM_USER`() {
       webTestClient.get().uri("/api/bookings/-3/activities")
         .headers(setClientAuthorisation(listOf("ROLE_SYSTEM_USER")))
         .exchange()
-        .expectStatus().isOk
+        .expectStatus().isForbidden
     }
 
     @Test
@@ -1401,11 +1401,11 @@ class BookingResourceIntTest : ResourceTest() {
     }
 
     @Test
-    fun `should return success when has ROLE_SYSTEM_USER override role`() {
+    fun `should return 403 when has ROLE_SYSTEM_USER override role`() {
       webTestClient.get().uri("/api/bookings/-6/property")
         .headers(setClientAuthorisation(listOf("ROLE_SYSTEM_USER")))
         .exchange()
-        .expectStatus().isOk
+        .expectStatus().isForbidden
     }
 
     @Test


### PR DESCRIPTION
Updated clients to also have VIEW_SCHEDULES role:
book-a-secure-move-api (Prod/Preprod/dev)
book-a-secure-move-api-uat (dev)
serco-book-a-secure-move (dev)