### PR TITLE
CRS-1779: Update NOMIS key dates with reason

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/RequestToUpdateOffenderDates.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/RequestToUpdateOffenderDates.java
@@ -35,6 +35,9 @@ public class RequestToUpdateOffenderDates {
     @Schema(description = "Comment to be associated with the sentence calculation, if not set a default comment is used")
     private String comment;
 
+    @Schema(description = "The reason the sentence calculation was performed, if not set the default reason is used")
+    private String reason;
+
     @Schema(description = "Is true, when there are no dates to be recorded in NOMIS")
     private boolean noDates;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
@@ -28,6 +28,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class OffenderDatesService {
 
     private static final String ZERO_LENGTH = "00/00/00";
+    private static final String DEFAULT_REASON = "UPDATE";
     private final OffenderBookingRepository offenderBookingRepository;
     private final StaffUserAccountRepository staffUserAccountRepository;
     private final TelemetryClient telemetryClient;
@@ -50,7 +51,7 @@ public class OffenderDatesService {
             sentenceCalculation =
                 SentenceCalculation.builder()
                     .offenderBooking(offenderBooking)
-                    .reasonCode("UPDATE")
+                    .reasonCode(isBlank(requestToUpdateOffenderDates.getReason()) ? DEFAULT_REASON : requestToUpdateOffenderDates.getReason())
                     .calculationDate(calculationDate)
                     .comments(
                         isBlank(requestToUpdateOffenderDates.getComment()) ?
@@ -87,7 +88,7 @@ public class OffenderDatesService {
         } else {
             sentenceCalculation = SentenceCalculation.builder()
                 .offenderBooking(offenderBooking)
-                .reasonCode("UPDATE")
+                .reasonCode(isBlank(requestToUpdateOffenderDates.getReason()) ? DEFAULT_REASON : requestToUpdateOffenderDates.getReason())
                 .calculationDate(calculationDate)
                 .effectiveSentenceLength(ZERO_LENGTH)
                 .comments(

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
@@ -223,7 +223,7 @@ public class OffenderDatesServiceTest {
     }
 
     @Test
-    void updateOffenderDates_with_passed_in_comment() {
+    void updateOffenderDates_with_passed_in_comment_and_reason() {
         // Given
         final Long bookingId = 1L;
         final var offenderBooking = OffenderBooking.builder().bookingId(bookingId).build();
@@ -240,6 +240,7 @@ public class OffenderDatesServiceTest {
             .calculationDateTime(calculationDateTime)
             .calculationUuid(calculationUuid)
             .comment("Passed in comment should override default")
+            .reason("TRANSFER")
             .build();
         final var keyDates = payload.getKeyDates();
 
@@ -249,7 +250,7 @@ public class OffenderDatesServiceTest {
         // Then
         final var expected = SentenceCalculation.builder()
             .offenderBooking(offenderBooking)
-            .reasonCode("UPDATE")
+            .reasonCode("TRANSFER")
             .calculationDate(calculationDateTime)
             .comments("Passed in comment should override default")
             .staff(staff)


### PR DESCRIPTION
Allows the reason for calculation in NOMIS to be updated with a reason selected by the CRDS user.