### PR TITLE
CDPS-607: Add more data to CSRA assessment endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/AssessmentDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/AssessmentDetail.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,11 +23,13 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class AssessmentDetail extends AssessmentSummary {
 
-    @Builder (builderMethodName = "detailBuilder")
+    @Builder(builderMethodName = "detailBuilder")
     public AssessmentDetail(final AssessmentSummary summary, final String assessmentAgencyId, final String assessmentComment,
                             final String assessmentCommitteeCode, final String assessmentCommitteeName, final LocalDate approvalDate,
                             final String approvalCommitteeCode, final String approvalCommitteeName, final String originalClassificationCode,
-                            final String classificationReviewReason, final List<AssessmentQuestion> questions) {
+                            final String classificationReviewReason, final List<AssessmentQuestion> questions, final String overridingClassificationCode,
+                            final String calculatedClassificationCode, final String approvedClassificationCode, final String approvalComment,
+                            final String overrideReason) {
         super(summary.getBookingId(), summary.getAssessmentSeq(), summary.getOffenderNo(), summary.getClassificationCode(),
             summary.getAssessmentCode(), summary.isCellSharingAlertFlag(), summary.getAssessmentDate(), summary.getAssessmentAgencyId(),
             summary.getAssessmentComment(), summary.getAssessorUser(), summary.getNextReviewDate());
@@ -36,8 +39,13 @@ public class AssessmentDetail extends AssessmentSummary {
         this.approvalCommitteeCode = approvalCommitteeCode;
         this.approvalCommitteeName = approvalCommitteeName;
         this.originalClassificationCode = originalClassificationCode;
-        this.classificationReviewReason = classificationReviewReason ;
+        this.classificationReviewReason = classificationReviewReason;
         this.questions = questions;
+        this.overridingClassificationCode = overridingClassificationCode;
+        this.calculatedClassificationCode = calculatedClassificationCode;
+        this.approvedClassificationCode = approvedClassificationCode;
+        this.approvalComment = approvalComment;
+        this.overrideReason = overrideReason;
     }
 
     @Schema(description = "The code of the committee that conducted the assessment", example = "REVIEW")
@@ -60,6 +68,21 @@ public class AssessmentDetail extends AssessmentSummary {
 
     @Schema(description = "The reason for the review of the classification", example = "HI")
     private String classificationReviewReason;
+
+    @Schema(description = "Overriding classification code", example = "HI")
+    private String overridingClassificationCode;
+
+    @Schema(description = "Originally calculated classification code", example = "HI")
+    private String calculatedClassificationCode;
+
+    @Schema(description = "Classification code at approval", example = "HI")
+    private String approvedClassificationCode;
+
+    @Schema(description = "Comment added at approval of classification code", example = "Comment")
+    private String approvalComment;
+
+    @Schema(description = "The reason given for overriding the calculated classification code", example = "Overriding comment")
+    private String overrideReason;
 
     @NotNull
     @Schema(description = "Assessment questions and answers, in the order they were asked")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/AssessmentDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/AssessmentDetail.java
@@ -69,13 +69,13 @@ public class AssessmentDetail extends AssessmentSummary {
     @Schema(description = "The reason for the review of the classification", example = "HI")
     private String classificationReviewReason;
 
-    @Schema(description = "Overriding classification code", example = "HI")
+    @Schema(description = "The classification code entered to override the calculated value prior to approval", example = "HI")
     private String overridingClassificationCode;
 
-    @Schema(description = "Originally calculated classification code", example = "HI")
+    @Schema(description = "The classification code originally calculated by NOMIS based on the answers given to the questions when carrying out the initial review", example = "HI")
     private String calculatedClassificationCode;
 
-    @Schema(description = "Classification code at approval", example = "HI")
+    @Schema(description = "The classification code that has been approved", example = "HI")
     private String approvedClassificationCode;
 
     @Schema(description = "Comment added at approval of classification code", example = "Comment")

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderAssessmentService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderAssessmentService.java
@@ -64,6 +64,11 @@ public class OffenderAssessmentService {
             .originalClassificationCode((classificationSummary.getOriginalClassification() != null)?classificationSummary.getOriginalClassification().getCode(): null)
             .classificationReviewReason(classificationSummary.getClassificationApprovalReason())
             .questions(getCsraAssessmentQuestionsAndAnswers(assessmentDetails, bookingId, assessmentSeq))
+            .overridingClassificationCode((assessmentDetails.getOverridingClassification() !=null)?assessmentDetails.getOverridingClassification().getCode():null)
+            .calculatedClassificationCode((assessmentDetails.getCalculatedClassification() !=null)?assessmentDetails.getCalculatedClassification().getCode():null)
+            .approvedClassificationCode((assessmentDetails.getReviewedClassification() !=null)?assessmentDetails.getReviewedClassification().getCode():null)
+            .approvalComment((assessmentDetails.getReviewCommitteeComment() !=null)?assessmentDetails.getReviewCommitteeComment():null)
+            .overrideReason((assessmentDetails.getOverrideReason() !=null)?assessmentDetails.getOverrideReason().getDescription():null)
             .build();
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderAssessmentService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderAssessmentService.java
@@ -67,7 +67,7 @@ public class OffenderAssessmentService {
             .overridingClassificationCode((assessmentDetails.getOverridingClassification() !=null)?assessmentDetails.getOverridingClassification().getCode():null)
             .calculatedClassificationCode((assessmentDetails.getCalculatedClassification() !=null)?assessmentDetails.getCalculatedClassification().getCode():null)
             .approvedClassificationCode((assessmentDetails.getReviewedClassification() !=null)?assessmentDetails.getReviewedClassification().getCode():null)
-            .approvalComment((assessmentDetails.getReviewCommitteeComment() !=null)?assessmentDetails.getReviewCommitteeComment():null)
+            .approvalComment(assessmentDetails.getReviewCommitteeComment())
             .overrideReason((assessmentDetails.getOverrideReason() !=null)?assessmentDetails.getOverrideReason().getDescription():null)
             .build();
     }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderAssessmentServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderAssessmentServiceTest.kt
@@ -97,6 +97,7 @@ class OffenderAssessmentServiceTest {
           .evaluationDate(LocalDate.parse("2019-01-03"))
           .overrideReason(AssessmentOverrideReason("OVERRIDE_DUMMY_VALUE", "Review reason"))
           .reviewCommittee(AssessmentCommittee("REVW", "Review board"))
+          .reviewCommitteeComment("Review comment")
           .nextReviewDate(LocalDate.parse("2020-01-02"))
           .build(),
       ),
@@ -138,6 +139,11 @@ class OffenderAssessmentServiceTest {
         .approvalCommitteeName("Review board")
         .originalClassificationCode("STANDARD")
         .classificationReviewReason("Review reason")
+        .calculatedClassificationCode("STANDARD")
+        .overridingClassificationCode("HI")
+        .approvedClassificationCode("HI")
+        .overrideReason("Review reason")
+        .approvalComment("Review comment")
         .questions(
           listOf(
             AssessmentQuestion.builder()

--- a/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/csra_assessment.json
+++ b/src/test/resources/uk/gov/justice/hmpps/prison/api/resource/impl/csra_assessment.json
@@ -8,27 +8,35 @@
   "assessmentDate": "2019-01-04",
   "assessmentAgencyId": "LEI",
   "assessmentComment": "A Comment",
+  "assessorUser": "JBRIEN",
+  "nextReviewDate": "2019-11-22",
   "assessmentCommitteeCode": "RECP",
   "assessmentCommitteeName": "Reception",
-  "assessorUser": "JBRIEN",
   "approvalDate": "2016-07-07",
   "approvalCommitteeCode": "GOV",
   "approvalCommitteeName": "Governor",
   "originalClassificationCode": "STANDARD",
   "classificationReviewReason": "Previous History",
-  "nextReviewDate": "2019-11-22",
-  "questions" : [
-      {
-          "question": "Reason for review",
-          "answer": "Scheduled"
-      },
-      {
-          "question": "Risk of harming a cell mate:",
-          "answer": "Standard"
-      },
-      {
-          "question": "Outcome of review:",
-          "answer": "A new plan must be agreed"
-      }
+  "overridingClassificationCode": "HI",
+  "calculatedClassificationCode": "STANDARD",
+  "approvedClassificationCode": "HI",
+  "approvalComment": "Review soon",
+  "overrideReason": "Previous History",
+  "questions": [
+    {
+      "question": "Reason for review",
+      "answer": "Scheduled",
+      "additionalAnswers": []
+    },
+    {
+      "question": "Risk of harming a cell mate:",
+      "answer": "Standard",
+      "additionalAnswers": []
+    },
+    {
+      "question": "Outcome of review:",
+      "answer": "A new plan must be agreed",
+      "additionalAnswers": []
+    }
   ]
 }


### PR DESCRIPTION
On the new prisoner profile CSRA pages we're looking to include more information which is currently available in NOMIS but not available in DPS for viewing - these fields are the ones added in this PR. 

Some of these fields are conditionally returned already
- the classification codes are returned via the existing `classificationCode` field
- the override reason/approval comment both get returned via `classificationReviewReason`

However as it already has internal logic in the API we were unable to display all of the fields to the user at once if required for a better understanding. Rather than update the logic in those fields (which may be used/depended on elsewhere) i opted to add new fields instead.