### PR TITLE
SDIT_1496 Remove SYSTEM_USER from BookingService.isViewInactiveBookings

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -1112,7 +1112,7 @@ public class BookingService {
     }
 
     private boolean isViewInactiveBookings() {
-        return authenticationFacade.isOverrideRole("INACTIVE_BOOKINGS", "SYSTEM_USER");
+        return authenticationFacade.isOverrideRole("INACTIVE_BOOKINGS");
     }
 
     private static String quotedAndPipeDelimited(final Stream<String> values) {

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/AgencyResourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/AgencyResourceTest.java
@@ -722,7 +722,6 @@ public class AgencyResourceTest extends ResourceTest {
             httpEntity,
             new ParameterizedTypeReference<String>() {
             });
-        System.out.println(response);
         assertThatJsonFileAndStatus(response, 200, "reception_with_capacity.json");
     }
 

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerResourceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerResourceTest.kt
@@ -241,6 +241,39 @@ class PrisonerResourceTest : ResourceTest() {
     }
 
     @Test
+    fun `does not return released prisoner release date when client does not have override role ROLE_INACTIVE_BOOKINGS`() {
+      webTestClient.get().uri("/api/prisoners/Z0020ZZ/full-status")
+        .headers(setClientAuthorisation(listOf("VIEW_PRISONER_DATA")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("establishmentCode").isEqualTo("OUT")
+        .jsonPath("releaseDate").doesNotExist()
+    }
+
+    @Test
+    fun `returns released prisoner release date when client has override role ROLE_INACTIVE_BOOKINGS`() {
+      webTestClient.get().uri("/api/prisoners/Z0020ZZ/full-status")
+        .headers(setClientAuthorisation(listOf("VIEW_PRISONER_DATA", "INACTIVE_BOOKINGS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("establishmentCode").isEqualTo("OUT")
+        .jsonPath("releaseDate").isNotEmpty
+    }
+
+    @Test
+    fun `does not return released prisoner release date when client has override role ROLE_SYSTEM_USER`() {
+      webTestClient.get().uri("/api/prisoners/Z0020ZZ/full-status")
+        .headers(setClientAuthorisation(listOf("VIEW_PRISONER_DATA", "SYSTEM_USER")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("establishmentCode").isEqualTo("OUT")
+        .jsonPath("releaseDate").doesNotExist()
+    }
+
+    @Test
     fun testReturn404WhenOffenderNotFound() {
       val httpEntity = createEmptyHttpEntity(AuthToken.VIEW_PRISONER_DATA)
       val response = testRestTemplate.exchange(


### PR DESCRIPTION
This affects the following endpoints:

- GET /api/offender-sentences
- POST /api/offender-sentences
- POST /api/offender-sentences/bookings
- GET /api/prisoners/{offenderNo}/full-status