### PR TITLE
MAP-494 Refactor capacity check methods in AgencyInternalLocation

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocation.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocation.java
@@ -142,8 +142,8 @@ public class AgencyInternalLocation {
         return isActive() && isReception();
     }
 
-    public boolean hasSpace(final boolean treatZeroOperationalCapacityAsNull) {
-        final var capacity = getActualCapacity(treatZeroOperationalCapacityAsNull);
+    public boolean hasSpace() {
+        final var capacity = getActualCapacity();
         return capacity != null && currentOccupancy != null && currentOccupancy < capacity;
     }
 
@@ -157,15 +157,15 @@ public class AgencyInternalLocation {
         return currentOccupancy;
     }
 
-    public boolean isActiveCellWithSpace(final boolean treatZeroOperationalCapacityAsNull) {
-        return isActiveCell() && hasSpace(treatZeroOperationalCapacityAsNull);
+    public boolean isActiveCellWithSpace() {
+        return isActiveCell() && hasSpace();
     }
-    public boolean isActiveReceptionWithSpace(final boolean treatZeroOperationalCapacityAsNull) {
-        return isActiveReception() && hasSpace(treatZeroOperationalCapacityAsNull);
+    public boolean isActiveReceptionWithSpace() {
+        return isActiveReception() && hasSpace();
     }
 
-    public Integer getActualCapacity(final boolean treatZeroOperationalCapacityAsNull) {
-        final var useOperationalCapacity = operationalCapacity != null && !(treatZeroOperationalCapacityAsNull && operationalCapacity == 0);
+    public Integer getActualCapacity() {
+        final var useOperationalCapacity = operationalCapacity != null && operationalCapacity != 0;
         return useOperationalCapacity ? operationalCapacity : capacity;
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/AgencyService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/AgencyService.java
@@ -389,7 +389,7 @@ public class AgencyService {
     public List<OffenderCell> getCellsWithCapacityInAgency(@NotNull final String agencyId, final String attribute) {
         final var cells = agencyInternalLocationRepository.findWithProfilesAgencyInternalLocationsByAgencyIdAndLocationTypeAndActive(agencyId, "CELL", true);
         return cells.stream()
-            .filter((l) -> l.isActiveCellWithSpace(true))
+            .filter((l) -> l.isActiveCellWithSpace())
             .map(cell -> transform(cell, true))
             .filter(cell -> attribute == null || cell.getAttributes().stream().anyMatch((a) -> a.getCode().equals(attribute)))
             .collect(toList());
@@ -398,7 +398,7 @@ public class AgencyService {
     public List<OffenderCell> getReceptionsWithCapacityInAgency(@NotNull final String agencyId, final String attribute) {
         final var receptions = agencyInternalLocationRepository.findWithProfilesAgencyInternalLocationsByAgencyIdAndLocationCodeAndActive(agencyId, "RECP", true);
         return receptions.stream()
-            .filter(l -> l.isActiveReceptionWithSpace(true))
+            .filter(l -> l.isActiveReceptionWithSpace())
             .map(recep -> transform(recep, true))
             .filter(recep -> attribute == null || recep.getAttributes().stream().anyMatch(a -> a.getCode().equals(attribute)))
             .collect(toList());
@@ -437,7 +437,7 @@ public class AgencyService {
                 .build())
             .collect(toList());
         return OffenderCell.builder()
-            .capacity(cell.getActualCapacity(treatZeroOperationalCapacityAsNull))
+            .capacity(cell.getActualCapacity())
             .noOfOccupants(cell.getCurrentOccupancy())
             .id(cell.getLocationId())
             .description(cell.getDescription())

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/MovementUpdateService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/MovementUpdateService.java
@@ -5,11 +5,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.hmpps.prison.api.model.CellMoveResult;
 import uk.gov.justice.hmpps.prison.api.model.OffenderBooking;
-import uk.gov.justice.hmpps.prison.core.HasWriteScope;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.AgencyInternalLocation;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.AgencyInternalLocationRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderBookingRepository;
-import uk.gov.justice.hmpps.prison.security.VerifyBookingAccess;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -55,7 +53,7 @@ public class MovementUpdateService {
         if (offenderBooking.getAssignedLivingUnitId().equals(internalLocation.getLocationId()))
             return transformToCellSwapResult(offenderBooking);
 
-        if (internalLocation.isActiveCellWithSpace(false) || internalLocation.isActiveReceptionWithSpace(false) )
+        if (internalLocation.isActiveCellWithSpace() || internalLocation.isActiveReceptionWithSpace() )
         {
             return saveAndReturnInternalMoveResult(bookingId, reasonCode, movementDateTime, internalLocation);
         }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/BookingIntoPrisonService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/BookingIntoPrisonService.kt
@@ -236,7 +236,7 @@ class BookingIntoPrisonService(
   ): Result<AgencyInternalLocation> =
     agencyInternalLocationRepository.findOneByDescriptionAndAgencyIdOrNull(internalLocationDescription, prison.id)
       ?.let {
-        it.takeIf { it.hasSpace(true) }?.let { internalLocation -> success(internalLocation) } ?: failure(
+        it.takeIf { it.hasSpace() }?.let { internalLocation -> success(internalLocation) } ?: failure(
           ConflictingRequestException.withMessage(
             "The cell $internalLocationDescription does not have any available capacity",
             CustomErrorCodes.NO_CELL_CAPACITY,

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/TransferIntoPrisonService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/TransferIntoPrisonService.kt
@@ -334,7 +334,7 @@ private fun ExternalMovement.assertIsActiveTAPTransfer(): Result<ExternalMovemen
 private fun ExternalMovement.isTransfer() = this.movementType.code == MovementType.TRN.code
 private fun ExternalMovement.isCourtTransfer() = this.movementType.code == MovementType.CRT.code
 private fun ExternalMovement.isTAPTransfer() = this.movementType.code == MovementType.TAP.code
-private fun AgencyInternalLocation.assertHasSpaceInCell(): Result<AgencyInternalLocation> = if (this.hasSpace(true)) {
+private fun AgencyInternalLocation.assertHasSpaceInCell(): Result<AgencyInternalLocation> = if (this.hasSpace()) {
   success(this)
 } else {
   failure(

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocationTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocationTest.java
@@ -50,19 +50,6 @@ public class AgencyInternalLocationTest {
     }
 
     @Test
-    public void testHasSpace_UseZeroOperationalCapacity(){
-        final var location = AgencyInternalLocation.builder()
-            .active(true)
-            .locationType("CELL")
-            .operationalCapacity(0)
-            .capacity(10)
-            .currentOccupancy(5)
-            .build();
-
-        assertThat(location.isActiveCellWithSpace()).isEqualTo(false);
-    }
-
-    @Test
     public void testHasSpace_NotFull(){
         final var location = AgencyInternalLocation.builder()
                 .active(true)

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocationTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/AgencyInternalLocationTest.java
@@ -33,7 +33,7 @@ public class AgencyInternalLocationTest {
                 .currentOccupancy(50)
                 .build();
 
-        assertThat(location.isActiveCellWithSpace(false)).isEqualTo(false);
+        assertThat(location.isActiveCellWithSpace()).isEqualTo(false);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class AgencyInternalLocationTest {
                 .currentOccupancy(5)
                 .build();
 
-        assertThat(location.isActiveCellWithSpace(true)).isEqualTo(true);
+        assertThat(location.isActiveCellWithSpace()).isEqualTo(true);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class AgencyInternalLocationTest {
             .currentOccupancy(5)
             .build();
 
-        assertThat(location.isActiveCellWithSpace(false)).isEqualTo(false);
+        assertThat(location.isActiveCellWithSpace()).isEqualTo(false);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class AgencyInternalLocationTest {
                 .currentOccupancy(50)
                 .build();
 
-        assertThat(location.isActiveCellWithSpace(false)).isEqualTo(true);
+        assertThat(location.isActiveCellWithSpace()).isEqualTo(true);
     }
 
 
@@ -84,7 +84,7 @@ public class AgencyInternalLocationTest {
                 .currentOccupancy(100)
                 .build();
 
-        assertThat(location.isActiveCellWithSpace(false)).isEqualTo(false);
+        assertThat(location.isActiveCellWithSpace()).isEqualTo(false);
     }
 
     @Test
@@ -97,19 +97,6 @@ public class AgencyInternalLocationTest {
             .currentOccupancy(5)
             .build();
 
-        assertThat(location.getActualCapacity(true)).isEqualTo(10);
-    }
-
-    @Test
-    public void testCapacity_UseZeroOperationalCapacity(){
-        final var location = AgencyInternalLocation.builder()
-            .active(true)
-            .locationType("CELL")
-            .operationalCapacity(0)
-            .capacity(10)
-            .currentOccupancy(5)
-            .build();
-
-        assertThat(location.getActualCapacity(false)).isEqualTo(0);
+        assertThat(location.getActualCapacity()).isEqualTo(10);
     }
 }


### PR DESCRIPTION
This commit removes the boolean parameter 'treatZeroOperationalCapacityAsNull' from the capacity check methods in AgencyInternalLocation class. Now the methods consider operational capacity as zero when it is null. The related tests and class methods that use those methods have also been updated accordingly.