### PR TITLE
SDIT-1579: 🐛 Fix sentence query and upgrade hibernate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,6 @@ dependencyCheck {
 val jsqlParserVersion by extra("4.6")
 
 ext["rest-assured.version"] = "5.3.2"
-ext["hibernate.version"] = "6.4.2.Final"
 
 dependencies {
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingId.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingId.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.hmpps.prison.repository.jpa.repository
+
+interface OffenderBookingId {
+  val bookingId: Long
+}

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
@@ -42,11 +42,16 @@ public interface OffenderBookingRepository extends
     @EntityGraph(type = EntityGraphType.FETCH, value = "booking-with-sentence-summary")
     List<OffenderBooking> findAllByBookingIdIn(List<Long> bookingIds);
 
-    @EntityGraph(type = EntityGraphType.FETCH, value = "booking-with-sentence-summary")
-    List<OffenderBooking> findAllOffenderBookingsByActiveTrueAndOffenderNomsIdInAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
+    /**
+     * Need a distinct here otherwise we will get the same offender bookings more than once as it does two left joins.
+     * Also workaround hibernate bug that seems to cause not enough sentence data to be returned, but splitting into
+     * this query and then calling findAllByBookingIdIn to get the data.
+     */
+    List<OffenderBookingId> findDistinctByActiveTrueAndOffenderNomsIdInAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
         Set<String> nomsIds,
         String status,
-        String calculationType, String category
+        String calculationType,
+        String category
     );
 
     Optional<OffenderBooking> findByBookingId(Long bookingId);

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
@@ -12,7 +12,6 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.AgencyLocation;
 import uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderBooking;
-import uk.gov.justice.hmpps.prison.repository.jpa.model.SentenceCalcType;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,10 +30,17 @@ public interface OffenderBookingRepository extends
     @EntityGraph(type = EntityGraphType.FETCH, value = "booking-with-sentence-summary")
     Optional<OffenderBooking> findWithSentenceSummaryByOffenderNomsIdAndBookingSequence(String nomsId, Integer bookingSequence);
 
-    @EntityGraph(type = EntityGraphType.FETCH, value = "booking-with-sentence-summary")
-    Page<OffenderBooking> findAllOffenderBookingsByActiveTrueAndLocationAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
+    /** Need a distinct here otherwise we will get the same offender bookings more than once as it does two left joins */
+    Page<OffenderBookingId> findDistinctByActiveTrueAndLocationAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
         AgencyLocation agencyLocation, String status, String calculationType, String category, Pageable pageable
     );
+
+    /**
+     * Separate version of the standard findAllById that uses the entity graph to load the data.  Paging should always
+     * be split out when doing a FETCH otherwise hibernate has to load all the data in memory.
+     */
+    @EntityGraph(type = EntityGraphType.FETCH, value = "booking-with-sentence-summary")
+    List<OffenderBooking> findAllByBookingIdIn(List<Long> bookingIds);
 
     @EntityGraph(type = EntityGraphType.FETCH, value = "booking-with-sentence-summary")
     List<OffenderBooking> findAllOffenderBookingsByActiveTrueAndOffenderNomsIdInAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -82,6 +82,7 @@ import uk.gov.justice.hmpps.prison.repository.jpa.model.VisitVisitor;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.AgencyLocationRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.CourtEventRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderBookingFilter;
+import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderBookingId;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderBookingRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderChargeRepository;
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderContactPersonsRepository;
@@ -848,12 +849,13 @@ public class BookingService {
     public Page<CalculableSentenceEnvelope> getCalculableSentenceEnvelopeByEstablishment(String caseLoad, int pageNumber, int pageSize) {
         final var agencyLocation = agencyLocationRepository.getReferenceById(caseLoad);
         PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, Sort.by("bookingId"));
-        final var activeBookings = offenderBookingRepository.findAllOffenderBookingsByActiveTrueAndLocationAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
+        final var bookingIds = offenderBookingRepository.findDistinctByActiveTrueAndLocationAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
             agencyLocation, "A", "%AGG%", "LICENCE", pageRequest
         );
+        final var activeBookings = offenderBookingRepository.findAllByBookingIdIn(bookingIds.stream().map(OffenderBookingId::getBookingId).toList());
         final var calculableSentenceEnvelopes = activeBookings.stream().map(this::determineCalculableSentenceEnvelope).toList();
 
-        return new PageImpl<>(calculableSentenceEnvelopes, pageRequest, activeBookings.getTotalElements());
+        return new PageImpl<>(calculableSentenceEnvelopes, pageRequest, bookingIds.getTotalElements());
     }
 
     public List<CalculableSentenceEnvelope> getCalculableSentenceEnvelopeByOffenderNumbers(Set<String> offenderNumbers) {

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -859,12 +859,13 @@ public class BookingService {
     }
 
     public List<CalculableSentenceEnvelope> getCalculableSentenceEnvelopeByOffenderNumbers(Set<String> offenderNumbers) {
-        final var activeBookings = offenderBookingRepository.findAllOffenderBookingsByActiveTrueAndOffenderNomsIdInAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
+        final var bookingIds = offenderBookingRepository.findDistinctByActiveTrueAndOffenderNomsIdInAndSentences_statusAndSentences_CalculationType_CalculationTypeNotLikeAndSentences_CalculationType_CategoryNot(
             offenderNumbers,
             "A",
             "%AGG%",
             "LICENCE"
         );
+        final var activeBookings = offenderBookingRepository.findAllByBookingIdIn(bookingIds.stream().map(OffenderBookingId::getBookingId).toList());
         return activeBookings.stream().map(this::determineCalculableSentenceEnvelope).toList();
     }
 


### PR DESCRIPTION
The original queries had two issues:
1. They were meant to return offender bookings, but these would sometimes be duplicated (if multiple sentences exist) as the query was eager fetching with a left outer join.  See https://developer.jboss.org/docs/DOC-15782#jive_content_id_Hibernate_does_not_return_distinct_results_for_a_query_with_outer_join_fetching_enabled_for_a_collection_even_if_I_use_the_distinct_keyword for more information
2. Pagination was specified with eager fetching.  This means that hibernate had to load the whole prison data into memory before then doing the paging.  See https://stackoverflow.com/questions/11431670/how-can-i-avoid-the-warning-firstresult-maxresults-specified-with-collection-fe