### PR TITLE
CRD-1849: fix docs and add latest calc timestamp to key offender dates

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderCalculatedKeyDates.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderCalculatedKeyDates.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Schema(description = "Offender Calculated Key Dates")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -25,13 +26,16 @@ public class OffenderCalculatedKeyDates extends OffenderKeyDates {
     private String comment;
     @Schema(description = "The reason code for the calculation", example = "NEW")
     private String reasonCode;
+    @Schema(description = "The date and time the calculation was recorded", example = "2017-10-31T01:30:00")
+    private LocalDateTime calculatedAt;
 
     @Builder(builderMethodName = "offenderCalculatedKeyDates")
-    public OffenderCalculatedKeyDates(LocalDate homeDetentionCurfewEligibilityDate, LocalDate earlyTermDate, LocalDate midTermDate, LocalDate lateTermDate, LocalDate dtoPostRecallReleaseDate, LocalDate automaticReleaseDate, LocalDate conditionalReleaseDate, LocalDate paroleEligibilityDate, LocalDate nonParoleDate, LocalDate licenceExpiryDate, LocalDate postRecallReleaseDate, LocalDate sentenceExpiryDate, LocalDate topupSupervisionExpiryDate, LocalDate earlyRemovalSchemeEligibilityDate, LocalDate effectiveSentenceEndDate, String sentenceLength, LocalDate releaseOnTemporaryLicenceDate, String judiciallyImposedSentenceLength, String comment, String reasonCode, LocalDate homeDetentionCurfewApprovedDate, LocalDate tariffDate, LocalDate tariffExpiredRemovalSchemeEligibilityDate, LocalDate approvedParoleDate) {
+    public OffenderCalculatedKeyDates(LocalDate homeDetentionCurfewEligibilityDate, LocalDate earlyTermDate, LocalDate midTermDate, LocalDate lateTermDate, LocalDate dtoPostRecallReleaseDate, LocalDate automaticReleaseDate, LocalDate conditionalReleaseDate, LocalDate paroleEligibilityDate, LocalDate nonParoleDate, LocalDate licenceExpiryDate, LocalDate postRecallReleaseDate, LocalDate sentenceExpiryDate, LocalDate topupSupervisionExpiryDate, LocalDate earlyRemovalSchemeEligibilityDate, LocalDate effectiveSentenceEndDate, String sentenceLength, LocalDate releaseOnTemporaryLicenceDate, String judiciallyImposedSentenceLength, String comment, String reasonCode, LocalDate homeDetentionCurfewApprovedDate, LocalDate tariffDate, LocalDate tariffExpiredRemovalSchemeEligibilityDate, LocalDate approvedParoleDate, LocalDateTime calculatedAt) {
         super(homeDetentionCurfewEligibilityDate, earlyTermDate, midTermDate, lateTermDate, dtoPostRecallReleaseDate, automaticReleaseDate, conditionalReleaseDate, paroleEligibilityDate, nonParoleDate, licenceExpiryDate, postRecallReleaseDate, sentenceExpiryDate, topupSupervisionExpiryDate, earlyRemovalSchemeEligibilityDate, effectiveSentenceEndDate, sentenceLength, homeDetentionCurfewApprovedDate, tariffDate, tariffExpiredRemovalSchemeEligibilityDate, approvedParoleDate, releaseOnTemporaryLicenceDate);
         this.releaseOnTemporaryLicenceDate = releaseOnTemporaryLicenceDate;
         this.judiciallyImposedSentenceLength = judiciallyImposedSentenceLength;
         this.comment = comment;
         this.reasonCode = reasonCode;
+        this.calculatedAt = calculatedAt;
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderKeyDates.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderKeyDates.java
@@ -80,7 +80,6 @@ public class OffenderKeyDates {
     @Schema(description = "APD - Approved Parole date", example = "2020-02-03")
     private LocalDate approvedParoleDate;
 
-
     @Schema(description = "ROTL = Release on temporary licence date", example = "2020-02-03")
     private LocalDate releaseOnTemporaryLicenceDate;
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderDatesResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderDatesResource.java
@@ -2,6 +2,7 @@ package uk.gov.justice.hmpps.prison.api.resource;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -58,7 +59,7 @@ public class OffenderDatesResource {
     }
 
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Offender key dates found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = SentenceCalcDates.class))}),
+        @ApiResponse(responseCode = "200", description = "Offender key dates found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = OffenderCalculatedKeyDates.class))}),
         @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "403", description = "Forbidden - user not authorised to update an offender's dates", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
@@ -74,7 +75,7 @@ public class OffenderDatesResource {
     }
 
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Offender calculations found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = OffenderSentenceCalculation.class))}),
+        @ApiResponse(responseCode = "200", description = "Offender calculations found", content = {@Content(mediaType = "application/json", array = @ArraySchema( schema = @Schema(implementation = SentenceCalculationSummary.class)))}),
         @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "403", description = "Forbidden - user not authorised to update an offender's dates", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
@@ -137,6 +137,7 @@ public class OffenderDatesService {
             .earlyRemovalSchemeEligibilityDate(sentenceCalculation.getErsedOverridedDate())
             .comment(sentenceCalculation.getComments())
             .reasonCode(sentenceCalculation.getReasonCode())
+            .calculatedAt(sentenceCalculation.getCalculationDate())
             .build();
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +36,7 @@ import static org.mockito.Mockito.when;
 public class OffenderDatesServiceTest {
 
     private static final LocalDate NOV_11_2021 = LocalDate.of(2021, 11, 8);
+    private static final LocalDateTime NOV_11_2021_10AM = LocalDateTime.of(2021, 11, 8, 10, 0, 0);
 
     @Mock
     private OffenderBookingRepository offenderBookingRepository;
@@ -45,7 +45,7 @@ public class OffenderDatesServiceTest {
     @Mock
     private TelemetryClient telemetryClient;
 
-    private final Clock clock  = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+    private final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
 
     private OffenderDatesService service;
 
@@ -110,11 +110,11 @@ public class OffenderDatesServiceTest {
         );
         assertEquals(Optional.of(expected), offenderBooking.getLatestCalculation());
         verify(telemetryClient).trackEvent("OffenderKeyDatesUpdated",
-                ImmutableMap.of(
-                    "bookingId", bookingId.toString(),
-                    "calculationUuid", calculationUuid.toString(),
-                    "submissionUser", submissionUser
-                ), null);
+            ImmutableMap.of(
+                "bookingId", bookingId.toString(),
+                "calculationUuid", calculationUuid.toString(),
+                "submissionUser", submissionUser
+            ), null);
     }
 
     @Test
@@ -287,7 +287,8 @@ public class OffenderDatesServiceTest {
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
             NOV_11_2021, NOV_11_2021, "11/00/00",
-            "11/00/00", NOV_11_2021, NOV_11_2021, "Comments", "NEW");
+            "11/00/00", NOV_11_2021, NOV_11_2021,
+            "Comments", "NEW" , NOV_11_2021_10AM);
     }
 
     public static OffenderKeyDates createOffenderKeyDates() {
@@ -305,8 +306,9 @@ public class OffenderDatesServiceTest {
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
             NOV_11_2021, NOV_11_2021, NOV_11_2021,
-            NOV_11_2021, NOV_11_2021, NOV_11_2021, "11/00/00",
-            "11/00/00", NOV_11_2021, "Comments", "NEW");
+            NOV_11_2021, NOV_11_2021, NOV_11_2021,
+            "11/00/00", "11/00/00", NOV_11_2021,
+            "Comments", "NEW", NOV_11_2021_10AM);
     }
 
     public static SentenceCalculation sentenceCalculation(LocalDate homeDetentionCurfewEligibilityDate,
@@ -328,7 +330,8 @@ public class OffenderDatesServiceTest {
                                                           LocalDate earlyRemovalSchemeEligibilityDate,
                                                           LocalDate releaseOnTemporaryLicenceDate,
                                                           String comment,
-                                                          String reasonCode) {
+                                                          String reasonCode,
+                                                          LocalDateTime calculationDate) {
 
         return SentenceCalculation.builder()
             .id(1L)
@@ -352,6 +355,7 @@ public class OffenderDatesServiceTest {
             .rotlOverridedDate(releaseOnTemporaryLicenceDate)
             .comments(comment)
             .reasonCode(reasonCode)
+            .calculationDate(calculationDate)
             .build();
     }
 
@@ -392,25 +396,26 @@ public class OffenderDatesServiceTest {
     }
 
     public static OffenderCalculatedKeyDates createOffenderCalculatedKeyDates(LocalDate homeDetentionCurfewEligibilityDate,
-                                                                             LocalDate earlyTermDate,
-                                                                             LocalDate midTermDate,
-                                                                             LocalDate lateTermDate,
-                                                                             LocalDate dtoPostRecallReleaseDate,
-                                                                             LocalDate automaticReleaseDate,
-                                                                             LocalDate conditionalReleaseDate,
-                                                                             LocalDate paroleEligibilityDate,
-                                                                             LocalDate nonParoleDate,
-                                                                             LocalDate licenceExpiryDate,
-                                                                             LocalDate postRecallReleaseDate,
-                                                                             LocalDate sentenceExpiryDate,
-                                                                             LocalDate topupSupervisionExpiryDate,
-                                                                             LocalDate earlyRemovalSchemeEligibilityDate,
-                                                                             LocalDate effectiveSentenceEndDate,
-                                                                             String sentenceLength,
-                                                                             String judiciallyImposedSentenceLength,
-                                                                             LocalDate releaseOnTemporaryLicenceDate,
-                                                                             String comment,
-                                                                             String reasonCode) {
+                                                                              LocalDate earlyTermDate,
+                                                                              LocalDate midTermDate,
+                                                                              LocalDate lateTermDate,
+                                                                              LocalDate dtoPostRecallReleaseDate,
+                                                                              LocalDate automaticReleaseDate,
+                                                                              LocalDate conditionalReleaseDate,
+                                                                              LocalDate paroleEligibilityDate,
+                                                                              LocalDate nonParoleDate,
+                                                                              LocalDate licenceExpiryDate,
+                                                                              LocalDate postRecallReleaseDate,
+                                                                              LocalDate sentenceExpiryDate,
+                                                                              LocalDate topupSupervisionExpiryDate,
+                                                                              LocalDate earlyRemovalSchemeEligibilityDate,
+                                                                              LocalDate effectiveSentenceEndDate,
+                                                                              String sentenceLength,
+                                                                              String judiciallyImposedSentenceLength,
+                                                                              LocalDate releaseOnTemporaryLicenceDate,
+                                                                              String comment,
+                                                                              String reasonCode,
+                                                                              LocalDateTime calculatedAt) {
         return OffenderCalculatedKeyDates.offenderCalculatedKeyDates()
             .homeDetentionCurfewEligibilityDate(homeDetentionCurfewEligibilityDate)
             .earlyTermDate(earlyTermDate)
@@ -432,6 +437,7 @@ public class OffenderDatesServiceTest {
             .releaseOnTemporaryLicenceDate(releaseOnTemporaryLicenceDate)
             .comment(comment)
             .reasonCode(reasonCode)
+            .calculatedAt(calculatedAt)
             .build();
     }
 }


### PR DESCRIPTION
Docs were pointing at the wrong types on 2 of the offender key dates endpoints. Added calculation timestamp to get offender key dates.