### PR TITLE
CDPS-690: Update CSRA Override behaviour

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessment.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessment.java
@@ -187,9 +187,17 @@ public class OffenderAssessment extends AuditableEntity {
         }
 
         if (overridingClassification != null && calculatedClassification != null) {
-            // If either of these is high it should be displayed as a priority
-            if (overridingClassification.getCode().equals("HI") || calculatedClassification.getCode().equals("HI")) {
-                return new ClassificationSummary(new AssessmentClassification("HI", "High"), null, null);
+            // We should display the highest one in order of priority
+            String[] priorities = new String[]{"HI", "STANDARD", "MED", "LOW"};
+
+            for (String priority : priorities) {
+                if (overridingClassification.getCode().equals(priority)) {
+                    return new ClassificationSummary(overridingClassification, null, null);
+                }
+
+                if (calculatedClassification.getCode().equals(priority)) {
+                    return new ClassificationSummary(calculatedClassification, null, null);
+                }
             }
         }
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessment.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessment.java
@@ -34,7 +34,7 @@ import java.util.List;
 import static org.hibernate.annotations.NotFoundAction.IGNORE;
 
 @Data
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -150,17 +150,17 @@ public class OffenderAssessment extends AuditableEntity {
     private LocalDate evaluationDate;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="CREATION_USER")
+    @JoinColumn(name = "CREATION_USER")
     private StaffUserAccount creationUser;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="ASSESSMENT_TYPE_ID")
+    @JoinColumn(name = "ASSESSMENT_TYPE_ID")
     private AssessmentEntry assessmentType;
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumns({
-        @JoinColumn(name="OFFENDER_BOOK_ID", referencedColumnName="OFFENDER_BOOK_ID"),
-        @JoinColumn(name="ASSESSMENT_SEQ", referencedColumnName="ASSESSMENT_SEQ")
+        @JoinColumn(name = "OFFENDER_BOOK_ID", referencedColumnName = "OFFENDER_BOOK_ID"),
+        @JoinColumn(name = "ASSESSMENT_SEQ", referencedColumnName = "ASSESSMENT_SEQ")
     })
     private List<OffenderAssessmentItem> assessmentItems;
 
@@ -185,8 +185,20 @@ public class OffenderAssessment extends AuditableEntity {
         if (reviewedClassification != null && !reviewedClassification.isPending()) {
             return new ClassificationSummary(reviewedClassification, getPreviousClassification(), getApprovalReason());
         }
+
+        if (overridingClassification != null && calculatedClassification != null) {
+            // If either of these is high it should be displayed as a priority
+            if (overridingClassification.getCode().equals("HI") || calculatedClassification.getCode().equals("HI")) {
+                return new ClassificationSummary(new AssessmentClassification("HI", "High"), null, null);
+            }
+        }
+
+        if(overridingClassification != null) {
+            return new ClassificationSummary(overridingClassification, null, null);
+        }
+
         if (calculatedClassification != null && !calculatedClassification.isPending() &&
-                overridingClassification == null) {
+            overridingClassification == null) {
             return new ClassificationSummary(calculatedClassification, null, null);
         }
         return ClassificationSummary.withoutClassification();

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessmentTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessmentTest.java
@@ -15,20 +15,31 @@ public class OffenderAssessmentTest {
     @MethodSource("classificationsWithExpectedResults")
     void classificationSummaryCalculation(final String calculatedClassificationCode, final String overrideClassificationCode, final String reviewedClassificationCode,
                                           final String reviewCommitteeComment, final String overrideReason, final String expectedFinalOutcome,
-                                          final String expectedOriginalOutcome, final String expectedApprovalReason)
-    {
+                                          final String expectedOriginalOutcome, final String expectedApprovalReason) {
         final var offenderAssessment = OffenderAssessment.builder()
             .calculatedClassification(generateClassification(calculatedClassificationCode))
             .overridingClassification(generateClassification(overrideClassificationCode))
             .reviewedClassification(generateClassification(reviewedClassificationCode))
             .reviewCommitteeComment(reviewCommitteeComment)
-            .overrideReason(overrideReason == null ? null: new AssessmentOverrideReason("OVERRIDE_DUMMY_VALUE", overrideReason))
+            .overrideReason(overrideReason == null ? null : new AssessmentOverrideReason("OVERRIDE_DUMMY_VALUE", overrideReason))
             .build();
         final var classificationSummary = offenderAssessment.getClassificationSummary();
 
         assertClassificationCodeEquals(classificationSummary.getFinalClassification(), expectedFinalOutcome);
         assertClassificationCodeEquals(classificationSummary.getOriginalClassification(), expectedOriginalOutcome);
         assertThat(classificationSummary.getClassificationApprovalReason()).isEqualTo(expectedApprovalReason);
+    }
+
+    @ParameterizedTest
+    @MethodSource("classificationPriorityWithExpectedResults")
+    void classificationSummaryPriority(final String calculatedClassificationCode, final String overrideClassificationCode, final String expectedClassificationCode) {
+        final var offenderAssessment = OffenderAssessment.builder()
+            .calculatedClassification(generateClassification(calculatedClassificationCode))
+            .overridingClassification(generateClassification(overrideClassificationCode))
+            .build();
+        final var classificationSummary = offenderAssessment.getClassificationSummary();
+
+        assertThat(classificationSummary.getFinalClassification().getCode()).isEqualTo(expectedClassificationCode);
     }
 
     @ParameterizedTest
@@ -68,18 +79,36 @@ public class OffenderAssessmentTest {
             arguments("STANDARD", "HI", "HI", "Approval Comment", "Override Comment", "HI", "STANDARD", "Override Comment"),
             arguments("STANDARD", "HI", "HI", "Approval Comment", null, "HI", "STANDARD", "Approval Comment"),
             arguments("STANDARD", "HI", "HI", null, null, "HI", "STANDARD", null),
-            // When STANDARD has been overridden with HI we should return the higher of the two
-            arguments("STANDARD", "HI", null, null, "Override Comment", "HI", null, null),
-            // When HI has been overridden with STANDARD we should return the higher of the two
             arguments("HI", "STANDARD", null, null, "Override Comment", "HI", null, null),
             arguments("STANDARD", "HI", "STANDARD", "Approval Comment", "Override Comment", "STANDARD", null, "Approval Comment"),
             arguments("STANDARD", null, "STANDARD", null, "Override Comment", "STANDARD", null, null),
             arguments(null, "HI", "STANDARD", "Approval Comment", "Override Comment", "STANDARD", null, "Override Comment"),
-            arguments(null, null, "STANDARD", "Approval Comment", "Override Comment","STANDARD", null, "Override Comment"),
+            arguments(null, null, "STANDARD", "Approval Comment", "Override Comment", "STANDARD", null, "Override Comment"),
             arguments("PEND", "STANDARD", "HI", "Approval Comment", "Override Comment", "HI", null, "Override Comment"),
             arguments("PEND", null, "HI", "Approval Comment", null, "HI", null, "Approval Comment"),
             arguments("PEND", null, null, null, null, null, null, null),
             arguments(null, null, null, null, null, null, null, null)
+        );
+    }
+
+    private static Stream<Arguments> classificationPriorityWithExpectedResults() {
+        return Stream.of(
+            arguments("HI", "HI", "HI"),
+            arguments("HI", "STANDARD", "HI"),
+            arguments("HI", "MED", "HI"),
+            arguments("HI", "LOW", "HI"),
+            arguments("STANDARD", "HI", "HI"),
+            arguments("STANDARD", "STANDARD", "STANDARD"),
+            arguments("STANDARD", "MED", "STANDARD"),
+            arguments("STANDARD", "LOW", "STANDARD"),
+            arguments("MED", "HI", "HI"),
+            arguments("MED", "STANDARD", "STANDARD"),
+            arguments("MED", "MED", "MED"),
+            arguments("MED", "LOW", "MED"),
+            arguments("LOW", "HI", "HI"),
+            arguments("LOW", "STANDARD", "STANDARD"),
+            arguments("LOW", "MED", "MED"),
+            arguments("LOW", "LOW", "LOW")
         );
     }
 

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessmentTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderAssessmentTest.java
@@ -68,7 +68,10 @@ public class OffenderAssessmentTest {
             arguments("STANDARD", "HI", "HI", "Approval Comment", "Override Comment", "HI", "STANDARD", "Override Comment"),
             arguments("STANDARD", "HI", "HI", "Approval Comment", null, "HI", "STANDARD", "Approval Comment"),
             arguments("STANDARD", "HI", "HI", null, null, "HI", "STANDARD", null),
-            arguments("STANDARD", "HI", null, null, "Override Comment", null, null, null),
+            // When STANDARD has been overridden with HI we should return the higher of the two
+            arguments("STANDARD", "HI", null, null, "Override Comment", "HI", null, null),
+            // When HI has been overridden with STANDARD we should return the higher of the two
+            arguments("HI", "STANDARD", null, null, "Override Comment", "HI", null, null),
             arguments("STANDARD", "HI", "STANDARD", "Approval Comment", "Override Comment", "STANDARD", null, "Approval Comment"),
             arguments("STANDARD", null, "STANDARD", null, "Override Comment", "STANDARD", null, null),
             arguments(null, "HI", "STANDARD", "Approval Comment", "Override Comment", "STANDARD", null, "Override Comment"),
@@ -83,7 +86,7 @@ public class OffenderAssessmentTest {
     private static Stream<Arguments> classificationsWithExpectedIsSetResults() {
         return Stream.of(
             arguments("STANDARD", "HI", "HI", true),
-            arguments("STANDARD", "HI", null, false),
+            arguments("STANDARD", "HI", null, true),
             arguments("STANDARD", null, "STANDARD", true),
             arguments("STANDARD", null, null, true),
             arguments(null, "HI", "STANDARD", true),


### PR DESCRIPTION
Following advice from security collegues the way the CSRA asessement is displayed has been changed. Instead of overrides returning a blank CSRA rating until approved - it now displays the higher of the two in case of it being HI until approved, at which point it will display the final result.