### PR TITLE
SDIT-1617 New endpoint dedicated to prisoner search

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/PrisonerSearchDetails.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/PrisonerSearchDetails.kt
@@ -1,0 +1,115 @@
+package uk.gov.justice.hmpps.prison.api.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "Prisoner details required by Prisoner Search")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class PrisonerSearchDetails(
+
+  @Schema(description = "Prisoner Number a.k.a NOMS number, offender number", example = "A1234AA")
+  val offenderNo: String,
+
+  @Schema(description = "Booking Id of the active booking", example = "432132")
+  val bookingId: Long? = null,
+
+  @Schema(description = "Booking Number of the active booking")
+  val bookingNo: String? = null,
+
+  @Schema(description = "Internal Offender ID")
+  val offenderId: Long,
+
+  @Schema(description = "Internal Root Offender ID")
+  val rootOffenderId: Long,
+
+  @Schema(description = "First Name")
+  val firstName: String,
+
+  @Schema(description = "Middle Name(s)")
+  val middleName: String? = null,
+
+  @Schema(description = "Last Name")
+  val lastName: String,
+
+  @Schema(description = "Date of Birth of prisoner", example = "1970-03-15")
+  val dateOfBirth: LocalDate,
+
+  @Schema(description = "Prison ID", example = "MDI")
+  val agencyId: String? = null,
+
+  @Schema(description = "List of alert details for the active booking")
+  val alerts: List<Alert>? = null,
+
+  @Schema(description = "Cell or location of the prisoner")
+  val assignedLivingUnit: AssignedLivingUnit? = null,
+
+  @Schema(description = "A set of physical attributes")
+  val physicalAttributes: PhysicalAttributes? = null,
+
+  @Schema(description = "List of physical characteristics")
+  val physicalCharacteristics: List<PhysicalCharacteristic>? = null,
+
+  @Schema(description = "List of profile information")
+  val profileInformation: List<ProfileInformation>? = null,
+
+  @Schema(description = "List of physical marks")
+  val physicalMarks: List<PhysicalMark>? = null,
+
+  @Schema(description = "CSRA (Latest assessment with cellSharing=true from list of assessments)")
+  val csra: String? = null,
+
+  @Schema(description = "Category code (from list of assessments)")
+  val categoryCode: String? = null,
+
+  @Schema(description = "In/Out Status", example = "IN, OUT, TRN")
+  val inOutStatus: String? = null,
+
+  @Schema(description = "Prisoner Identifiers")
+  val identifiers: List<OffenderIdentifier>? = null,
+
+  @Schema(description = "Sentence Detail")
+  val sentenceDetail: SentenceCalcDates? = null,
+
+  @Schema(description = "Most serious offence")
+  val mostSeriousOffenceDescription: String? = null,
+
+  @Schema(description = "Currently serving an indeterminate sentence?")
+  val indeterminateSentence: Boolean? = null,
+
+  @Schema(description = "Aliases")
+  val aliases: List<Alias>? = null,
+
+  @Schema(description = "Status of prisoner", example = "ACTIVE IN, ACTIVE OUT, INACTIVE OUT, INACTIVE TRN")
+  val status: String? = null,
+
+  @Schema(
+    description = "Last Movement Type Code of prisoner. Note: Reference Data from MOVE_TYPE Domain",
+    example = "TAP, CRT, TRN, ADM, REL",
+  )
+  val lastMovementTypeCode: String? = null,
+
+  @Schema(description = "Last Movement Reason of prisoner. Note: Reference Data from MOVE_RSN Domain", example = "CA")
+  val lastMovementReasonCode: String? = null,
+
+  @Schema(description = "Legal Status", example = "REMAND")
+  val legalStatus: LegalStatus? = null,
+
+  @Schema(description = "Recall", example = "true")
+  val recall: Boolean? = null,
+
+  @Schema(description = "The prisoner's imprisonment status", example = "LIFE")
+  val imprisonmentStatus: String? = null,
+
+  @Schema(description = "The prisoner's imprisonment status description", example = "Serving Life Imprisonment")
+  val imprisonmentStatusDescription: String? = null,
+
+  @Schema(description = "Date prisoner was received into the prison.", example = "1980-01-01")
+  val receptionDate: LocalDate? = null,
+
+  @Schema(description = "current prison or outside with last movement information.", example = "Outside - released from Leeds")
+  val locationDescription: String? = null,
+
+  @Schema(description = "the current prison id or the last prison before release", example = "MDI")
+  val latestLocationId: String? = null,
+)

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/PrisonerSearchResource.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/PrisonerSearchResource.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.hmpps.prison.api.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.hmpps.prison.api.model.ErrorResponse
+import uk.gov.justice.hmpps.prison.api.model.PrisonerSearchDetails
+import uk.gov.justice.hmpps.prison.service.PrisonerSearchService
+
+@RestController
+@Tag(name = "prisoner-search")
+@RequestMapping(value = ["\${api.base.path}/prisoner-search"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@PreAuthorize("hasRole('PRISONER_INDEX')")
+class PrisonerSearchResource(private val service: PrisonerSearchService) {
+
+  @GetMapping("/offenders/{offenderNo}")
+  @Operation(
+    summary = "Returns details required by Prisoner Search for the given offender number.",
+    description = "This endpoint is dedicated to returning the details required by Prisoner Search so the role and endpoint are not for general use. If you're thinking of calling this endpoint try calling Prisoner Search instead.",
+  )
+  @ApiResponses(
+    ApiResponse(
+      responseCode = "200",
+      description = "OK",
+      content = [Content(mediaType = "application/json", schema = Schema(implementation = PrisonerSearchDetails::class))],
+    ),
+    ApiResponse(
+      responseCode = "401",
+      description = "Unauthorized to access this endpoint",
+      content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+    ),
+    ApiResponse(
+      responseCode = "403",
+      description = "Requires role ROLE_PRISONER_INDEX",
+      content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+    ),
+    ApiResponse(
+      responseCode = "404",
+      description = "Requested resource not found.",
+      content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+    ),
+  )
+  fun getPrisonerDetails(
+    @PathVariable("offenderNo") @Parameter(description = "offenderNo", example = "A1234AA") offenderNo: String,
+  ): PrisonerSearchDetails = service.getPrisonerDetails(offenderNo)
+}

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -207,7 +207,7 @@ public class BookingService {
         this.maxBatchSize = maxBatchSize;
     }
 
-    @VerifyBookingAccess(overrideRoles = {"GLOBAL_SEARCH", "VIEW_PRISONER_DATA"})
+    @VerifyBookingAccess(overrideRoles = {"GLOBAL_SEARCH", "VIEW_PRISONER_DATA", "PRISONER_INDEX"})
     public SentenceCalcDates getBookingSentenceCalcDates(final Long bookingId) {
 
         final var sentenceCalcDates = getSentenceCalcDates(bookingId);

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.hmpps.prison.service
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.hmpps.prison.api.model.PrisonerSearchDetails
+
+@Component
+class PrisonerSearchService(private val inmateService: InmateService) {
+
+  fun getPrisonerDetails(offenderNo: String): PrisonerSearchDetails =
+    inmateService.findOffender(offenderNo, true, false)
+      .let {
+        PrisonerSearchDetails(
+          offenderNo = it.offenderNo,
+          bookingId = it.bookingId,
+          bookingNo = it.bookingNo,
+          offenderId = it.offenderId,
+          rootOffenderId = it.rootOffenderId,
+          firstName = it.firstName,
+          middleName = it.middleName,
+          lastName = it.lastName,
+          dateOfBirth = it.dateOfBirth,
+          agencyId = it.agencyId,
+          alerts = it.alerts,
+          assignedLivingUnit = it.assignedLivingUnit,
+          physicalAttributes = it.physicalAttributes,
+          physicalCharacteristics = it.physicalCharacteristics,
+          profileInformation = it.profileInformation,
+          physicalMarks = it.physicalMarks,
+          csra = it.csra,
+          categoryCode = it.categoryCode,
+          inOutStatus = it.inOutStatus,
+          identifiers = it.identifiers,
+          sentenceDetail = it.sentenceDetail,
+          mostSeriousOffenceDescription = it.offenceHistory?.firstOrNull { it.mostSerious }?.offenceDescription,
+          indeterminateSentence = it.sentenceTerms?.any { st -> st.lifeSentence && it.bookingId == st.bookingId },
+          aliases = it.aliases,
+          status = it.status,
+          lastMovementTypeCode = it.lastMovementTypeCode,
+          lastMovementReasonCode = it.lastMovementReasonCode,
+          legalStatus = it.legalStatus,
+          recall = it.recall,
+          imprisonmentStatus = it.imprisonmentStatus,
+          imprisonmentStatusDescription = it.imprisonmentStatusDescription,
+          receptionDate = it.receptionDate,
+          locationDescription = it.locationDescription,
+          latestLocationId = it.latestLocationId,
+        )
+      }
+}

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
@@ -1,0 +1,253 @@
+package uk.gov.justice.hmpps.prison.api.resource.impl
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.hmpps.prison.api.model.Alert
+import uk.gov.justice.hmpps.prison.api.model.LegalStatus
+import uk.gov.justice.hmpps.prison.api.model.PhysicalMark
+import uk.gov.justice.hmpps.prison.api.model.PrisonerSearchDetails
+import uk.gov.justice.hmpps.prison.api.model.ProfileInformation
+import uk.gov.justice.hmpps.prison.repository.jpa.model.SentenceCalculation.NonDtoReleaseDateType
+import java.time.LocalDate
+
+class PrisonerSearchResourceIntTest : ResourceTest() {
+
+  @Nested
+  @DisplayName("GET /api/prisoner-search/offenders/{offenderNo}")
+  inner class OffenderDetails {
+
+    @Test
+    fun `should return 401 without an auth token`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AB")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `should return 403 with no roles`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AB")
+        .headers(setAuthorisation(listOf()))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return 403 with wrong role`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AB")
+        .headers(setAuthorisation(listOf("ROLE_SYSTEM_USER")))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return ok with correct role`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AB")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .exchange()
+        .expectStatus().isOk
+    }
+
+    @Test
+    fun `should return not found`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/UNKNOWN")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody().jsonPath("userMessage").isEqualTo("Resource with id [UNKNOWN] not found.")
+    }
+
+    @Test
+    fun `should return all data`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AB")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<PrisonerSearchDetails>()
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            assertThat(offenderNo).isEqualTo("A1234AB")
+            assertThat(bookingId).isEqualTo(-2)
+            assertThat(bookingNo).isEqualTo("A00112")
+            assertThat(offenderId).isEqualTo(-1002)
+            assertThat(rootOffenderId).isEqualTo(-1002)
+            assertThat(firstName).isEqualTo("GILLIAN")
+            assertThat(middleName).isEqualTo("EVE")
+            assertThat(lastName).isEqualTo("ANDERSON")
+            assertThat(dateOfBirth).isEqualTo("1998-08-28")
+            assertThat(agencyId).isEqualTo("LEI")
+            assertThat(alerts).extracting(Alert::getAlertType, Alert::getAlertCode).containsExactlyInAnyOrder(
+              tuple("H", "HA"),
+              tuple("X", "XTACT"),
+            )
+            with(assignedLivingUnit!!) {
+              assertThat(agencyId).isEqualTo("LEI")
+              assertThat(locationId).isEqualTo(-19)
+              assertThat(description).isEqualTo("H-1-5")
+              assertThat(agencyName).isEqualTo("Leeds")
+            }
+            with(physicalAttributes!!) {
+              assertThat(gender).isEqualTo("Female")
+              assertThat(raceCode).isEqualTo("W2")
+              assertThat(ethnicity).isEqualTo("White: Irish")
+              assertThat(weightPounds).isEqualTo(120)
+              assertThat(weightKilograms).isEqualTo(55)
+              assertThat(sexCode).isEqualTo("F")
+            }
+            assertThat(physicalCharacteristics).extracting("type", "characteristic", "detail").containsExactly(
+              tuple("FACE", "Shape of Face", "Round"),
+            )
+            assertThat(profileInformation).containsExactlyInAnyOrder(
+              ProfileInformation("RELF", "Religion", "Baptist"),
+              ProfileInformation("SMOKE", "Is the Offender a smoker?", "No"),
+              ProfileInformation("NAT", "Nationality?", "Israeli"),
+            )
+            assertThat(physicalMarks).isEmpty()
+            assertThat(csra).isNull()
+            assertThat(categoryCode).isNull()
+            assertThat(inOutStatus).isEqualTo("IN")
+            assertThat(identifiers).isEmpty()
+            with(sentenceDetail!!) {
+              assertThat(sentenceExpiryDate).isEqualTo("2019-05-21")
+              assertThat(automaticReleaseDate).isEqualTo("2018-05-21")
+              assertThat(releaseOnTemporaryLicenceDate).isEqualTo("2018-02-25")
+              assertThat(bookingId).isEqualTo(-2)
+              assertThat(sentenceStartDate).isEqualTo("2017-05-22")
+              assertThat(automaticReleaseOverrideDate).isEqualTo("2018-04-21")
+              assertThat(nonDtoReleaseDate).isEqualTo("2018-04-21")
+              assertThat(nonDtoReleaseDateType).isEqualTo(NonDtoReleaseDateType.ARD)
+              assertThat(confirmedReleaseDate).isEqualTo("2018-04-19")
+              assertThat(releaseDate).isEqualTo("2018-04-19")
+            }
+            assertThat(mostSeriousOffenceDescription).isNull()
+            assertThat(indeterminateSentence).isTrue()
+            assertThat(aliases).isEmpty()
+            assertThat(status).isEqualTo("ACTIVE IN")
+            assertThat(lastMovementTypeCode).isEqualTo("ADM")
+            assertThat(lastMovementReasonCode).isEqualTo("24")
+            assertThat(legalStatus).isEqualTo(LegalStatus.SENTENCED)
+            assertThat(recall).isTrue()
+            assertThat(imprisonmentStatus).isEqualTo("SENT")
+            assertThat(imprisonmentStatusDescription).isEqualTo("Adult Imprisonment Without Option")
+            assertThat(receptionDate).isEqualTo("2024-04-10")
+            assertThat(locationDescription).isEqualTo("Leeds")
+            assertThat(latestLocationId).isEqualTo("LEI")
+          }
+        }
+    }
+
+    @Test
+    fun `should return more data not on previous test`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AC")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<PrisonerSearchDetails>()
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            assertThat(offenderNo).isEqualTo("A1234AC")
+            assertThat(physicalMarks).isEmpty()
+            assertThat(csra).isEqualTo("Low")
+            assertThat(categoryCode).isEqualTo("X")
+            assertThat(identifiers).extracting("type", "value", "offenderNo", "issuedDate", "caseloadType")
+              .containsExactly(
+                tuple("CRO", "CRO112233", "A1234AC", LocalDate.parse("2017-07-13"), "INST"),
+              )
+            assertThat(mostSeriousOffenceDescription).isNull()
+            assertThat(aliases).isEmpty()
+          }
+        }
+    }
+
+    @Test
+    fun `should return physical marks`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AA")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<PrisonerSearchDetails>()
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            assertThat(physicalMarks).containsExactly(
+              PhysicalMark(null, "Tattoo", null, "Torso", null, "Some Comment Text", null),
+            )
+          }
+        }
+    }
+
+    @Test
+    fun `should return aliases`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AI")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<PrisonerSearchDetails>()
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            assertThat(aliases).extracting("firstName", "lastName", "dob", "gender", "ethnicity", "createDate")
+              .containsExactlyInAnyOrder(
+                tuple(
+                  "CHESNEY",
+                  "THOMSON",
+                  LocalDate.parse("1980-01-02"),
+                  "Male",
+                  "Mixed: White and Black African",
+                  LocalDate.parse("2015-01-01"),
+                ),
+                tuple(
+                  "CHARLEY",
+                  "THOMPSON",
+                  LocalDate.parse("1998-11-01"),
+                  "Male",
+                  "White: British",
+                  LocalDate.parse("2015-02-01"),
+                ),
+              )
+          }
+        }
+    }
+
+    @Test
+    fun `should return most serious offence`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AA")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<PrisonerSearchDetails>()
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            assertThat(mostSeriousOffenceDescription).isEqualTo("Cause exceed max permitted wt of artic' vehicle - No of axles/configuration (No MOT/Manufacturer's Plate)")
+          }
+        }
+    }
+
+    @Test
+    fun `should return minimum details if no booking`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234DD")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<PrisonerSearchDetails>()
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            assertThat(offenderNo).isEqualTo("A1234DD")
+            assertThat(offenderId).isEqualTo(-1056)
+            assertThat(rootOffenderId).isEqualTo(-1056)
+            assertThat(firstName).isEqualTo("JOHN")
+            assertThat(lastName).isEqualTo("DOE")
+            assertThat(dateOfBirth).isEqualTo(LocalDate.parse("1989-03-02"))
+          }
+        }
+    }
+  }
+}


### PR DESCRIPTION
This is the first PR in a multi-stage plan to switch to a new endpoint deicated to prisoner search.

- first we've created an endpoint that only includes details required by prisoner search
- for now this is calling the old InmateService to get data, and testing against the same old seed data
- we will then create a test fixture in prisoner search to compare the old and new endpoints with production data to give us confidence that the new endpoint works the same as the old one
- once established we can switch prisoner search to the new endpoint
- we will then be able to add additional data to the new endpoint without affecting other prison-api clients
- then we'll rewrite the tests for the new endpoint such that we don't rely on the seed data
- once we're happy with the test coverage we will write a new service to back the new endpoint
- at this point we're isolated from the old endpoint and service