### PR TITLE
SDIT-1617 Start moving towards JPA instead of InmateService

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/InmateDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/InmateDetail.java
@@ -205,16 +205,16 @@ public class InmateDetail {
         updateReligion();
     }
 
-    private void updateReligion() {
-        if (profileInformation == null) {
-            return;
-        }
-        religion = profileInformation
+    public InmateDetail updateReligion() {
+        if (profileInformation != null) {
+            religion = profileInformation
                 .stream()
                 .filter(pi -> "RELF".equals(pi.getType()))
                 .findFirst()
                 .map(ProfileInformation::getResultValue)
                 .orElse(null);
+        }
+        return this;
     }
 
     public InmateDetail splitStatusReason() {

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenceHistoryDetail.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenceHistoryDetail.java
@@ -86,4 +86,9 @@ public class OffenceHistoryDetail {
 
     public OffenceHistoryDetail() {
     }
+
+    public Boolean convicted() {
+        return (this.primaryResultConviction!= null && this.primaryResultConviction)
+            || (this.secondaryResultConviction != null && this.secondaryResultConviction);
+    }
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/InmateService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/InmateService.java
@@ -309,7 +309,7 @@ public class InmateService {
         }
     }
 
-    private List<Assessment> getAllAssessmentsOrdered(final Long bookingId) {
+    public List<Assessment> getAllAssessmentsOrdered(final Long bookingId) {
         final var assessmentsDto = repository.findAssessments(Collections.singletonList(bookingId), null, Collections.emptySet());
 
         return assessmentsDto.stream().map(this::createAssessment).toList();
@@ -400,6 +400,10 @@ public class InmateService {
             .stream()
             .filter(i -> identifierType == null || identifierType.equalsIgnoreCase(i.getType()))
             .toList();
+    }
+
+    public List<Alias> getAliases(final Long bookingId) {
+        return repository.findInmateAliasesByBooking(bookingId, "createDate", Order.ASC, 0, 100).getItems().stream().toList();
     }
 
     @Transactional // route to primary in live so that we can get the latest data after a trigger

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
@@ -1,13 +1,25 @@
 package uk.gov.justice.hmpps.prison.service
 
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Component
+import uk.gov.justice.hmpps.prison.api.model.InmateDetail
 import uk.gov.justice.hmpps.prison.api.model.PrisonerSearchDetails
+import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderBookingRepository
+import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderRepository
+import uk.gov.justice.hmpps.prison.service.transformers.OffenderTransformer
+import java.util.Optional
 
 @Component
-class PrisonerSearchService(private val inmateService: InmateService) {
+class PrisonerSearchService(
+  private val offenderBookingRepository: OffenderBookingRepository,
+  private val offenderRepository: OffenderRepository,
+  private val offenderTransformer: OffenderTransformer,
+  private val inmateService: InmateService,
+) {
 
+  @Transactional
   fun getPrisonerDetails(offenderNo: String): PrisonerSearchDetails =
-    inmateService.findOffender(offenderNo, true, false)
+    getInmateDetail(offenderNo)
       .let {
         PrisonerSearchDetails(
           offenderNo = it.offenderNo,
@@ -30,7 +42,7 @@ class PrisonerSearchService(private val inmateService: InmateService) {
           inOutStatus = it.inOutStatus,
           identifiers = it.identifiers,
           sentenceDetail = it.sentenceDetail,
-          mostSeriousOffence = it.offenceHistory?.firstOrNull { it.mostSerious }?.offenceDescription,
+          mostSeriousOffence = it.offenceHistory?.filter { off -> off.bookingId == it.bookingId }?.firstOrNull { it.mostSerious }?.offenceDescription,
           indeterminateSentence = it.sentenceTerms?.any { st -> st.lifeSentence && it.bookingId == st.bookingId },
           aliases = it.aliases,
           status = it.status,
@@ -45,4 +57,26 @@ class PrisonerSearchService(private val inmateService: InmateService) {
           latestLocationId = it.latestLocationId,
         )
       }
+
+  private fun getInmateDetail(offenderNo: String): InmateDetail {
+    val booking = offenderBookingRepository.findLatestOffenderBookingByNomsId(offenderNo).toNullable()
+    val offender = booking?.offender ?: offenderRepository.findRootOffenderByNomsId(offenderNo).toNullable()
+    if (offender == null) throw EntityNotFoundException.withId(offenderNo)
+    return booking
+      ?.let { offenderTransformer.transform(it) }
+      ?.apply {
+        // TODO These need to be modelled in JPA and set by the OffenderTransformer
+        physicalAttributes = inmateService.getPhysicalAttributes(bookingId)
+        physicalCharacteristics = inmateService.getPhysicalCharacteristics(bookingId)
+        physicalMarks = inmateService.getPhysicalMarks(bookingId)
+        aliases = inmateService.getAliases(bookingId)
+        inmateService.getAllAssessmentsOrdered(bookingId).also {
+          csra = it.firstOrNull { it.isCellSharingAlertFlag }?.classification
+          categoryCode = it.firstOrNull { "CATEGORY" == it.assessmentCode }?.classificationCode
+        }
+      }
+      ?: let { offenderTransformer.transformWithoutBooking(offender) }
+  }
 }
+
+private fun <T> Optional<T>.toNullable(): T? = orElse(null)

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/TransferIntoPrisonServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/enteringandleaving/TransferIntoPrisonServiceTest.kt
@@ -34,13 +34,14 @@ import uk.gov.justice.hmpps.prison.service.ConflictingRequestException
 import uk.gov.justice.hmpps.prison.service.CourtHearingsService
 import uk.gov.justice.hmpps.prison.service.EntityNotFoundException
 import uk.gov.justice.hmpps.prison.service.PrisonToPrisonMoveSchedulingService
+import uk.gov.justice.hmpps.prison.service.transformers.OffenderChargeTransformer
 import uk.gov.justice.hmpps.prison.service.transformers.OffenderTransformer
 import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
 
-internal class TransferIntoPrisonServiceTest {
+class TransferIntoPrisonServiceTest {
   private val externalMovementService: ExternalMovementService = mock()
   private val bedAssignmentMovementService: BedAssignmentMovementService = mock()
   private val trustAccountService: TrustAccountService = mock()
@@ -52,7 +53,8 @@ internal class TransferIntoPrisonServiceTest {
   private val agencyInternalLocationRepository: AgencyInternalLocationRepository = mock()
   private val agencyLocationRepository: AgencyLocationRepository = mock()
   private val teamWorkflowNotificationService: TeamWorkflowNotificationService = mock()
-  private val transformer: OffenderTransformer = OffenderTransformer(Clock.systemDefaultZone())
+  private val offenderChargeTransformer: OffenderChargeTransformer = mock()
+  private val transformer: OffenderTransformer = OffenderTransformer(Clock.systemDefaultZone(), offenderChargeTransformer)
 
   private val fromPrison = AgencyLocation().apply {
     description = "HMPS Brixton"
@@ -160,6 +162,7 @@ internal class TransferIntoPrisonServiceTest {
           birthDate = LocalDate.now().minusYears(30)
           gender = Gender("M", "MALE")
         }
+        bookingBeginDate = LocalDateTime.now().minusDays(1)
       }
       whenever(offenderBookingRepository.findByOffenderNomsIdAndBookingSequence("A1234AK", 1)).thenReturn(
         Optional.of(
@@ -313,6 +316,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -336,6 +340,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -361,6 +366,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -386,6 +392,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -454,6 +461,7 @@ internal class TransferIntoPrisonServiceTest {
           birthDate = LocalDate.now().minusYears(30)
           gender = Gender("M", "MALE")
         }
+        bookingBeginDate = LocalDateTime.now().minusDays(1)
       }
       whenever(offenderBookingRepository.findByOffenderNomsIdAndBookingSequence("A1234AK", 1)).thenReturn(
         Optional.of(
@@ -533,6 +541,7 @@ internal class TransferIntoPrisonServiceTest {
             birthDate = LocalDate.now().minusYears(30)
             gender = Gender("M", "MALE")
           }
+          bookingBeginDate = LocalDateTime.now().minusDays(1)
         }
 
         whenever(offenderBookingRepository.findByOffenderNomsIdAndBookingSequence("A1234AK", 1)).thenReturn(
@@ -604,6 +613,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -627,6 +637,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -652,6 +663,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -675,6 +687,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -706,6 +719,7 @@ internal class TransferIntoPrisonServiceTest {
           birthDate = LocalDate.now().minusYears(30)
           gender = Gender("M", "MALE")
         }
+        bookingBeginDate = LocalDateTime.now().minusDays(1)
       }
       whenever(offenderBookingRepository.findByOffenderNomsIdAndBookingSequence("A1234AK", 1)).thenReturn(
         Optional.of(
@@ -867,6 +881,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -890,6 +905,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -915,6 +931,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -951,6 +968,7 @@ internal class TransferIntoPrisonServiceTest {
           birthDate = LocalDate.now().minusYears(30)
           gender = Gender("M", "MALE")
         }
+        bookingBeginDate = LocalDateTime.now().minusDays(1)
       }
       whenever(offenderBookingRepository.findByOffenderNomsIdAndBookingSequence("A1234AK", 1)).thenReturn(
         Optional.of(
@@ -1030,6 +1048,7 @@ internal class TransferIntoPrisonServiceTest {
             birthDate = LocalDate.now().minusYears(30)
             gender = Gender("M", "MALE")
           }
+          bookingBeginDate = LocalDateTime.now().minusDays(1)
         }
 
         whenever(offenderBookingRepository.findByOffenderNomsIdAndBookingSequence("A1234AK", 1)).thenReturn(
@@ -1101,6 +1120,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -1124,6 +1144,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -1149,6 +1170,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -1172,6 +1194,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -1203,6 +1226,7 @@ internal class TransferIntoPrisonServiceTest {
           birthDate = LocalDate.now().minusYears(30)
           gender = Gender("M", "MALE")
         }
+        bookingBeginDate = LocalDateTime.now().minusDays(1)
       }
       whenever(offenderBookingRepository.findByOffenderNomsIdAndBookingSequence("A1234AK", 1)).thenReturn(
         Optional.of(
@@ -1364,6 +1388,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -1387,6 +1412,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )
@@ -1412,6 +1438,7 @@ internal class TransferIntoPrisonServiceTest {
               birthDate = LocalDate.now().minusYears(30)
               gender = Gender("M", "MALE")
             }
+            bookingBeginDate = LocalDateTime.now().minusDays(1)
           },
         ),
       )


### PR DESCRIPTION
This is for the new prisoner search endpoint that's not being used **yet** - it's being tested in parallel with the old endpoint to make sure it provides the same details. We don't want to get this wrong so we're testing with real data.

The idea is to move the endpoint away from InmateService (which relies heavily on SQL based repositories) and onto JPA instead. We haven't achieved this yet but this but are now using JPA modelling where it exists (still more to do).