### PR TITLE
MAP-1357-deprecate-endpoints-in-prison-api-and-whereabouts-api

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AgencyResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/AgencyResource.java
@@ -180,6 +180,7 @@ public class AgencyResource {
     @ReferenceData(description = "Agency data is considered non-sensitive")
     @GetMapping("/{agencyId}/locations")
     @SlowReportQuery
+    @Deprecated(forRemoval = true)
     public List<Location> getAgencyLocations(
         @PathVariable("agencyId") @Parameter(required = true) final String agencyId,
         @RequestParam(value = "eventType", required = false) @Parameter(description = "Restricts list of locations returned to those that can be used for the specified event type.") final String eventType,
@@ -228,6 +229,7 @@ public class AgencyResource {
     @Operation(summary = "List of active internal locations for agency by type.", description = "List of active internal locations for agency by type.")
     @ReferenceData(description = "Agency data is considered non-sensitive")
     @GetMapping("/{agencyId}/locations/type/{type}")
+    @Deprecated(forRemoval = true)
     public List<Location> getAgencyLocationsByType(
         @PathVariable("agencyId") @Parameter(description = "The prison", required = true) final String agencyId,
         @PathVariable("type") @Parameter(description = "Restricts list of locations returned to those of the passed type.", required = true) final String type
@@ -255,6 +257,7 @@ public class AgencyResource {
     @Operation(summary = "List of all available Location Groups at agency.", description = "List of all available Location Groups at agency.")
     @ReferenceData(description = "Agency data is considered non-sensitive")
     @GetMapping("/{agencyId}/locations/groups")
+    @Deprecated(forRemoval = true)
     public List<LocationGroup> getAvailableLocationGroups(@PathVariable("agencyId") @Parameter(description = "The prison", required = true) final String agencyId) {
         return locationGroupService.getLocationGroupsForAgency(agencyId);
     }

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/CellResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/CellResource.java
@@ -81,6 +81,7 @@ public class CellResource {
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @Operation(summary = "Get details of a location.")
     @GetMapping("/{locationId}/attributes")
+    @Deprecated(forRemoval = true)
     @ReferenceData(description = "Cell Attributes only")
     public OffenderCell getCellAttributes(@PathVariable("locationId") @Parameter(description = "The location id.", required = true) final Long locationId) {
         return agencyService.getCellAttributes(locationId);

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/LocationResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/LocationResource.java
@@ -102,6 +102,7 @@ public class LocationResource {
     @Operation(summary = "Location detail.", description = "Location detail.")
     @GetMapping("/{locationId}")
     @ReferenceData(description = "Location properties only are returned, no prisoner data")
+    @Deprecated(forRemoval = true)
     public Location getLocation(
         @PathVariable("locationId")
         @Parameter(description = "The location id of location", required = true)
@@ -122,6 +123,7 @@ public class LocationResource {
     @Operation(summary = "Returns the location (internal) for a prison based on description")
     @GetMapping("/code/{code}")
     @ReferenceData(description = "Location properties only are returned, no prisoner data")
+    @Deprecated(forRemoval = true)
     public Location getLocationByCode(
         @PathVariable("code") @Parameter(example = "MDI-1", required = true) final String code) {
            return locationService.getLocationByCode(code).orElseThrow(EntityNotFoundException.withId(code));


### PR DESCRIPTION
Marked several methods in the AgencyResource, LocationResource, and CellResource classes as deprecated. The Location service will provide this data in the future.

Methods shown [here](https://docs.google.com/spreadsheets/d/1xa0MJNMreQcqONtS9alkF_5Hg3NvWSCckDIyr2KQOXA/edit?usp=sharing)