### PR TITLE
BAVL-213 adds the event id to the response object on the schedules appointment search endpoint so appointments can be explicitly identified.

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/sql/ScheduleRepositorySql.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/sql/ScheduleRepositorySql.kt
@@ -261,6 +261,7 @@ enum class ScheduleRepositorySql(val sql: String) {
         SELECT O.OFFENDER_ID_DISPLAY AS OFFENDER_NO,
         O.FIRST_NAME,
         O.LAST_NAME,
+        OIS.EVENT_ID,
         OIS.EVENT_SUB_TYPE AS EVENT,
         RC2.DESCRIPTION AS EVENT_DESCRIPTION,
         OIS.START_TIME,

--- a/src/test/java/uk/gov/justice/hmpps/prison/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/repository/ScheduleRepositoryTest.java
@@ -149,6 +149,7 @@ public class ScheduleRepositoryTest {
         final var date = LocalDate.parse("2017-05-12");
         final var results = repository.getAppointments("LEI", Collections.singletonList("A1234AB"), date);
         assertThat(results).hasSize(1);
+        assertThat(results.get(0).getEventId()).isEqualTo(-16);
         assertThat(results.get(0).getOffenderNo()).isEqualTo("A1234AB");
         assertThat(results.get(0).getStartTime()).isEqualTo(LocalDateTime.parse("2017-05-12T09:30"));
         assertThat(results.get(0).getEvent()).isEqualTo("IMM");


### PR DESCRIPTION
The BLVS service needs to be able to make amendments to appointments in NOMIS.

To do this we need the appointment event ID (which we don't store in our service).  To achieve this we have to search for appointments based on criteria we do hold e.g. prison code, prisoner number, date, etc.