### PR TITLE
SDIT-1842 Get last modified height and weight for prisoner search

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderBooking.java
@@ -308,6 +308,13 @@ public class OffenderBooking extends AuditableEntity {
     @PrimaryKeyJoinColumn
     private ReleaseDetail releaseDetail;
 
+    @OneToMany(mappedBy = "id.offenderBooking", cascade = CascadeType.ALL)
+    @OrderColumn(name = "ATTRIBUTE_SEQ")
+    @ListIndexBase(1)
+    @Default
+    @Exclude
+    private List<OffenderPhysicalAttributes> offenderPhysicalAttributes = new ArrayList<>();
+
     public void addSentenceCalculation(final SentenceCalculation sc) {
         sentenceCalculations.add(sc);
         sc.setOffenderBooking(this);
@@ -789,6 +796,16 @@ public class OffenderBooking extends AuditableEntity {
             }
         }
         return null;
+    }
+
+    public OffenderPhysicalAttributes getLatestPhysicalAttributes() {
+        return offenderPhysicalAttributes.stream().max(Comparator.comparing((pa) -> {
+            if (pa.getModifyDatetime() != null) {
+                return pa.getModifyDatetime();
+            } else {
+                return pa.getCreateDatetime();
+            }
+        })).orElse(null);
     }
 
     public static Integer getDaysForKeyDateAdjustmentsCode(final List<KeyDateAdjustment> adjustmentsList, final String code) {

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderPhysicalAttributes.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/model/OffenderPhysicalAttributes.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.hmpps.prison.repository.jpa.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType.LAZY
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import uk.gov.justice.hmpps.prison.repository.jpa.helper.EntityOpen
+import java.io.Serializable
+
+@Embeddable
+data class OffenderPhysicalAttributeId(
+  @ManyToOne(optional = false, fetch = LAZY)
+  @JoinColumn(name = "OFFENDER_BOOK_ID", nullable = false)
+  val offenderBooking: OffenderBooking,
+
+  @Column(name = "ATTRIBUTE_SEQ", nullable = false)
+  val sequence: Long,
+) : Serializable
+
+@Entity
+@Table(name = "OFFENDER_PHYSICAL_ATTRIBUTES")
+@EntityOpen
+internal class OffenderPhysicalAttributes(
+  @EmbeddedId
+  val id: OffenderPhysicalAttributeId,
+
+  @Column(name = "HEIGHT_FT")
+  val heightFeet: Int? = null,
+
+  @Column(name = "HEIGHT_IN")
+  val heightInches: Int? = null,
+
+  @Column(name = "HEIGHT_CM")
+  val heightCentimetres: Int? = null,
+
+  @Column(name = "WEIGHT_LBS")
+  val weightPounds: Int? = null,
+
+  @Column(name = "WEIGHT_KG")
+  val weightKgs: Int? = null,
+) : AuditableEntity()

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
@@ -78,7 +78,6 @@ class PrisonerSearchService(
       ?.let { offenderTransformer.transform(it) }
       ?.apply {
         // TODO These need to be modelled in JPA and set by the OffenderTransformer
-        physicalAttributes = inmateService.getPhysicalAttributes(bookingId)
         physicalCharacteristics = inmateService.getPhysicalCharacteristics(bookingId)
         physicalMarks = inmateService.getPhysicalMarks(bookingId)
         aliases = inmateService.getAliases(bookingId)

--- a/src/main/resources/db/migration/data/R__4_15__OFFENDER_PHYSICAL_ATTRIBUTES.sql
+++ b/src/main/resources/db/migration/data/R__4_15__OFFENDER_PHYSICAL_ATTRIBUTES.sql
@@ -1,12 +1,12 @@
-INSERT INTO OFFENDER_PHYSICAL_ATTRIBUTES (OFFENDER_BOOK_ID, ATTRIBUTE_SEQ, HEIGHT_FT, HEIGHT_IN, HEIGHT_CM, WEIGHT_LBS, WEIGHT_KG)
-    VALUES  (-1, 1, 5, 6, 168, 165, 75),
-            (-1, 2, 3, 4, 155, 167, 75),
-            (-2, 1, null, null, null, 120, 55),
-            (-3, 1, 5, 10, 178, null, null),
-            (-4, 1, 6, 1, 185, 218, 99),
-            (-5, 1, 6, 0, 183, 190, 86),
-            (-6, 1, 6, 2, 188, null, null),
-            (-7, 1, 5, 11, 180, 196, 89),
-            (-8, 1, 5, 11, 180, null, null),
-            (-9, 1, 5, 10, 178, 185, 84),
-            (-10, 1, 6, 6, 198, 235, 107);
+INSERT INTO OFFENDER_PHYSICAL_ATTRIBUTES (OFFENDER_BOOK_ID, ATTRIBUTE_SEQ, HEIGHT_FT, HEIGHT_IN, HEIGHT_CM, WEIGHT_LBS, WEIGHT_KG, CREATE_DATETIME, MODIFY_DATETIME)
+    VALUES  (-1, 1, 5, 6, 168, 165, 75, TIMESTAMP '2015-01-01 00:00:00.000000', TIMESTAMP '2015-01-03 00:00:00.000000'),
+            (-1, 2, 3, 4, 155, 169, 77, TIMESTAMP '2015-01-02 00:00:00.000000', TIMESTAMP '2015-01-04 00:00:00.000000'),
+            (-2, 1, null, null, null, 120, 55, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-3, 1, 5, 10, 178, null, null, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-4, 1, 6, 1, 185, 218, 99, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-5, 1, 6, 0, 183, 190, 86, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-6, 1, 6, 2, 188, null, null, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-7, 1, 5, 11, 180, 196, 89, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-8, 1, 5, 11, 180, null, null, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-9, 1, 5, 10, 178, 185, 84, TIMESTAMP '2015-01-02 00:00:00.000000', null),
+            (-10, 1, 6, 6, 198, 235, 107, TIMESTAMP '2015-01-02 00:00:00.000000', null);

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
@@ -411,6 +411,22 @@ class PrisonerSearchResourceIntTest : ResourceTest() {
     }
 
     @Test
+    fun `should return last modified physical attributes`() {
+      webTestClient.get().uri("/api/prisoner-search/offenders/A1234AA")
+        .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<PrisonerSearchDetails>()
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            assertThat(physicalAttributes?.heightCentimetres).isEqualTo(155)
+            assertThat(physicalAttributes?.weightKilograms).isEqualTo(77)
+          }
+        }
+    }
+
+    @Test
     fun `should return minimum details if no booking`() {
       webTestClient.get().uri("/api/prisoner-search/offenders/A1234DD")
         .headers(setAuthorisation(listOf("ROLE_PRISONER_INDEX")))


### PR DESCRIPTION
We previously always took the `OFFENDER_PHYSICAL_ATTRIBUTES` record with `ATTRIBUTE_SEQ=1`. The prisoner profile team asked if we could send them the last modified record that for the sync. to DPS - this is the latest value entered by a user. However this would cause discrepancies with Prisoner Search which still displays the first sequence.

Therefore this PR changes the prisoner search endpoint to return the last modified physical attributes and so will align with DPS.