### PR TITLE
SDIT-1882 Include duplicate merge offences for prisoner search

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderChargeRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderChargeRepository.java
@@ -13,6 +13,9 @@ public interface OffenderChargeRepository extends CrudRepository<OffenderCharge,
     @EntityGraph(type = EntityGraphType.FETCH, value = "charges-details")
     List<OffenderCharge> findByOffenderBooking_BookingIdInAndChargeStatusAndOffenderCourtCase_CaseStatus_Code(Set<Long> bookingIds, String chargeStatus, String caseStatusCode);
 
+    @EntityGraph(type = EntityGraphType.FETCH, value = "charges-details")
+    List<OffenderCharge> findByOffenderBooking_BookingId(Long bookingId);
+
     @Query("""
       SELECT oc from OffenderBooking ob
       join OffenderCharge oc on ob.bookingId = oc.offenderBooking.bookingId

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
@@ -251,9 +251,11 @@ class PrisonerSearchResourceIntTest : ResourceTest() {
           with(response.responseBody!!) {
             assertThat(allConvictedOffences)
               .extracting("bookingId", "offenceCode")
-              // ignores charges with no convicted result, ignores MERGE duplicates, includes charges that are inactive
+              // ignores charges with no convicted result
               .containsExactlyInAnyOrder(
                 tuple(-12L, "M1"),
+                tuple(-13L, "M2"),
+                // Note that the duplicate for SYS/MERGE is included
                 tuple(-13L, "M2"),
               )
           }
@@ -277,8 +279,7 @@ class PrisonerSearchResourceIntTest : ResourceTest() {
       webTestClient.getPrisonerSearchDetails("A5577RS")
         .consumeWith { response ->
           with(response.responseBody!!) {
-            // Note that this ignores charge M2=Common Assault with the highest severity - because it has AUDIT_MODULE_NAME = 'MERGE'
-            assertThat(mostSeriousOffence).isEqualTo("Attempted Murder")
+            assertThat(mostSeriousOffence).isEqualTo("Common assault")
           }
         }
     }


### PR DESCRIPTION
We previously copied some functionality from the SQL driven endpoints to ignore offences copied during a merge (with create user SYS and audit module MERGE). However we realised this removes the active charge on the new booking rather than the inactive charge on the old booking. This is bad - for example it could corrupt the recall flag if we ignore an active recall charge. So we've decided to remove that functionality entirely and accept the duplicate charge in the "all convicted offences" data. Most users should only be interested in active offences which should be retrieved from the DPS offences API.