### PR TITLE
SDIT-2264: ✨ Add mojo allowlist for dev and pre-prod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,7 +16,8 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - moj_cloud_platform
+      - digital_staff_and_mojo
       - circleci
 
     # found in app insights logs for unilink client

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,7 +16,8 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
+      - moj_cloud_platform
       - prum-test
       - mod-platform-non-live # oasys-api-client
       - delius-preprod


### PR DESCRIPTION
`internal` looks to be deprecated anyway now - see https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml#L26.
Suggestion is
>     internal: # Deprecated, use digital_staff_and_mojo or moj_cloud_platform or both, as appropriate for your service
which is what I've implemented.