### PR TITLE
CRS-2224 Change method that retrieves latest TUSED calculated date to be booking agnostic (previously it ignored the latest booking)

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderDatesResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/OffenderDatesResource.java
@@ -115,7 +115,7 @@ public class OffenderDatesResource {
         @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
     })
-    @Operation(summary = "Get the latest TUSED data for an offender. If the offender has had a previous TUSED recorded on a previous booking this will return the latest one", description = "Requires RELEASE_DATES_CALCULATOR")
+    @Operation(summary = "Get the latest TUSED data for an offender. This will return the latest calculated TUSED for an offender", description = "Requires RELEASE_DATES_CALCULATOR")
     @GetMapping("/latest-tused/{nomsId}")
     @PreAuthorize("hasRole('RELEASE_DATES_CALCULATOR')")
     @ProxyUser

--- a/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/repository/jpa/repository/OffenderBookingRepository.java
@@ -85,8 +85,8 @@ public interface OffenderBookingRepository extends
     @Query("""
     SELECT new uk.gov.justice.hmpps.prison.api.model.LatestTusedData(sc.tusedCalculatedDate, sc.tusedOverridedDate, sc.comments, o.nomsId)
     from SentenceCalculation sc
-    inner join sc.offenderBooking.offender o where o.nomsId = :nomsId and sc.offenderBooking.bookingId != :bookingId and coalesce(sc.tusedOverridedDate, sc.tusedCalculatedDate) is not null
+    inner join sc.offenderBooking.offender o where o.nomsId = :nomsId and coalesce(sc.tusedOverridedDate, sc.tusedCalculatedDate) is not null
     order by sc.calculationDate desc limit 1
     """)
-    Optional<LatestTusedData> findLatestTusedDataFromNomsId(@NotNull String nomsId, Long bookingId);
+    Optional<LatestTusedData> findLatestTusedDataFromNomsId(@NotNull String nomsId);
 }

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/OffenderDatesService.java
@@ -158,8 +158,7 @@ public class OffenderDatesService {
     }
 
     public LatestTusedData getLatestTusedDataFromNomsId(String nomsId) {
-            return offenderBookingRepository.findLatestOffenderBookingByNomsId(nomsId)
-        .flatMap(ob -> offenderBookingRepository.findLatestTusedDataFromNomsId(nomsId, ob.getBookingId()))
-        .orElseThrow(EntityNotFoundException.withId(nomsId));
+        return offenderBookingRepository.findLatestTusedDataFromNomsId(nomsId)
+            .orElseThrow(EntityNotFoundException.withId(nomsId));
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/OffenderDatesServiceTest.java
@@ -387,8 +387,7 @@ public class OffenderDatesServiceTest {
     @Test
     void findLatestTusedDataIsReturnedCorrectly() {
         LatestTusedData latestTusedData = new LatestTusedData(LocalDate.of(2023, 1, 3), null, null, "A1234AA");
-        when(offenderBookingRepository.findLatestOffenderBookingByNomsId(anyString())).thenReturn(Optional.of(OffenderBooking.builder().bookingId(2L).build()));
-        when(offenderBookingRepository.findLatestTusedDataFromNomsId(anyString(), anyLong())).thenReturn(Optional.of(latestTusedData));
+        when(offenderBookingRepository.findLatestTusedDataFromNomsId(anyString())).thenReturn(Optional.of(latestTusedData));
         LatestTusedData returned = service.getLatestTusedDataFromNomsId("A1234AA");
         assertThat(returned.getOffenderNo()).isEqualTo("A1234AA");
         assertThat(returned.getLatestTused()).isEqualTo(LocalDate.of(2023, 1, 3));
@@ -396,15 +395,7 @@ public class OffenderDatesServiceTest {
 
     @Test
     void findLatestTusedDataThrowsExpectedException() {
-        when(offenderBookingRepository.findLatestOffenderBookingByNomsId(anyString())).thenReturn(Optional.of(OffenderBooking.builder().bookingId(2L).build()));
-        when(offenderBookingRepository.findLatestTusedDataFromNomsId(anyString(), anyLong())).thenReturn(Optional.empty());
-        Throwable exception = assertThrows(EntityNotFoundException.class, () -> service.getLatestTusedDataFromNomsId("A1234AA"));
-        assertThat(exception.getMessage()).isEqualTo("Resource with id [A1234AA] not found.");
-    }
-
-    @Test
-    void findLatestTusedDataThrowsExpectedExceptionWhenBookingIsntPresent() {
-        when(offenderBookingRepository.findLatestOffenderBookingByNomsId(anyString())).thenReturn(Optional.empty());
+        when(offenderBookingRepository.findLatestTusedDataFromNomsId(anyString())).thenReturn(Optional.empty());
         Throwable exception = assertThrows(EntityNotFoundException.class, () -> service.getLatestTusedDataFromNomsId("A1234AA"));
         assertThat(exception.getMessage()).isEqualTo("Resource with id [A1234AA] not found.");
     }


### PR DESCRIPTION
this functionality is only used by the calculate-release-dates service