### PR TITLE
Give Integration API Access to non-associations endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/GangResource.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/GangResource.kt
@@ -42,7 +42,7 @@ class GangResource(private val gangService: GangService) {
     ),
   )
   @Operation(summary = "Returns a list of gangs for a prisoner and the gang non-associations and their members")
-  @PreAuthorize("hasRole('VIEW_GANG')")
+  @PreAuthorize("hasAnyRole('VIEW_GANG', 'PRISON_API__HMPPS_INTEGRATION_API')")
   @GetMapping("/non-associations/{offenderNo}")
   fun getNonAssociationGangsForPrisoner(
     @PathVariable

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/GangResource.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/GangResource.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.hmpps.prison.service.GangService
 
 @RestController
 @Tag(name = "gang")
+@Tag(name = "integration-api")
 @Validated
 @RequestMapping(value = ["/api/gang"], produces = ["application/json"])
 class GangResource(private val gangService: GangService) {


### PR DESCRIPTION
To allow the HMPPS Integration API to expose this information to Private Prisons