### PR TITLE
Fix API Schema

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/AddressDto.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/AddressDto.java
@@ -63,13 +63,13 @@ public class AddressDto {
     @Schema(description = "Comment", example = "This is a comment text")
     private String comment;
 
-    @Schema(requiredMode = REQUIRED, description = "Primary Address", example = "Y")
+    @Schema(requiredMode = REQUIRED, description = "Primary Address", example = "true")
     private Boolean primary;
 
-    @Schema(requiredMode = REQUIRED, description = "Mail Address", example = "Y")
+    @Schema(requiredMode = REQUIRED, description = "Mail Address", example = "true")
     private Boolean mail;
 
-    @Schema(requiredMode = REQUIRED, description = "No Fixed Address", example = "N")
+    @Schema(requiredMode = REQUIRED, description = "No Fixed Address", example = "false")
     private Boolean noFixedAddress;
 
     @Schema(description = "Date Added", example = "2005-05-12")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderRestriction.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/OffenderRestriction.java
@@ -28,10 +28,10 @@ public class OffenderRestriction {
     @Schema(description = "Restriction comment text")
     private String comment;
 
-    @Schema(requiredMode = REQUIRED, description = "code of restriction type")
+    @Schema(requiredMode = REQUIRED, description = "code of restriction type", example = "ACC")
     private String restrictionType;
 
-    @Schema(requiredMode = REQUIRED, description = "description of restriction type")
+    @Schema(requiredMode = REQUIRED, description = "description of restriction type", example = "Access Requirements")
     @NotBlank
     private String restrictionTypeDescription;
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/RequestToUpdateAddress.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/RequestToUpdateAddress.java
@@ -52,10 +52,10 @@ public class RequestToUpdateAddress {
     @Schema(description = "Comment", example = "This is a comment text")
     private String comment;
 
-    @Schema(requiredMode = REQUIRED, description = "Primary Address", example = "Y")
+    @Schema(requiredMode = REQUIRED, description = "Primary Address", example = "true")
     private boolean primary;
 
-    @Schema(requiredMode = REQUIRED, description = "No Fixed Address", example = "N")
+    @Schema(requiredMode = REQUIRED, description = "No Fixed Address", example = "false")
     private boolean noFixedAddress;
 
     @Schema(description = "Date Added", example = "2005-05-12")

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/v1/CreateTransaction.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/v1/CreateTransaction.java
@@ -24,7 +24,7 @@ import java.math.RoundingMode;
 public class CreateTransaction {
 
     @NotNull
-    @Schema(description = "Valid transaction type for the prison_id", example = "CANT", allowableValues = "CANT,REFND,PHONE,MRPR,MTDS,DTDS,CASHD,RELA,RELS")
+    @Schema(description = "Valid transaction type for the prison_id", example = "CANT", allowableValues = {"CANT", "REFND", "PHONE", "MRPR", "MTDS", "DTDS", "CASHD", "RELA", "RELS"})
     private String type;
 
     @Size(max = 240)


### PR DESCRIPTION
Due to a change in the last few months, the API schema is producing a new output. We noticed this because it is impacting the mock produced by Prism. I've made a few changes to produce a cleaner mock including:
- Fixing booleans
- Splitting a list of allowed values as a string into a list of strings
- Introducing examples for some fields