### PR TITLE
SDIT-2760: 🔥 Remove unused POST /api/bookings/mainOffence

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingResource.java
@@ -428,19 +428,6 @@ public class BookingResource {
         @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
-    @Operation(summary = "Get Offender main offence detail.", description = "Post version to allow specifying a large number of bookingIds. Requires role VIEW_PRISONER_DATA")
-    @PreAuthorize("hasRole('VIEW_PRISONER_DATA')")
-    @PostMapping("/mainOffence")
-    @SlowReportQuery
-    public List<OffenceDetail> getMainOffence(@RequestBody @Parameter(description = "The bookingIds to identify the offenders", required = true) final Set<Long> bookingIds) {
-        return bookingService.getMainOffenceDetails(bookingIds);
-    }
-
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-        @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-        @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @Operation(summary = "Offence history.", description = "All Offences recorded for this offender.")
     @Tag(name = "integration-api")
     @GetMapping("/offenderNo/{offenderNo}/offenceHistory")

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/BookingService.java
@@ -560,19 +560,6 @@ public class BookingService {
         return sentenceRepository.getMainOffenceDetails(bookingId);
     }
 
-    public List<OffenceDetail> getMainOffenceDetails(final Set<Long> bookingIds) {
-
-        final List<OffenceDetail> results = new ArrayList<>();
-        if (!CollectionUtils.isEmpty(bookingIds)) {
-            final var batch = Lists.partition(new ArrayList<>(bookingIds), maxBatchSize);
-            batch.forEach(bookingBatch -> {
-                final var offences = sentenceRepository.getMainOffenceDetails(bookingBatch);
-                results.addAll(offences);
-            });
-        }
-        return results;
-    }
-
     public List<OffenceHistoryDetail> getOffenceHistory(final String offenderNo, final boolean convictionsOnly) {
         return sentenceRepository.getOffenceHistory(offenderNo, convictionsOnly);
     }

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingResourceIntTest.kt
@@ -817,60 +817,6 @@ class BookingResourceIntTest : ResourceTest() {
   }
 
   @Nested
-  @DisplayName("POST /api/bookings/mainOffence")
-  inner class MainOffence {
-
-    @Test
-    fun `should return 401 when user does not even have token`() {
-      webTestClient.post().uri("/api/bookings/mainOffence")
-        .header("Content-Type", APPLICATION_JSON_VALUE)
-        .bodyValue("[-1, -7]")
-        .exchange()
-        .expectStatus().isUnauthorized
-    }
-
-    @Test
-    fun `returns 403 when client does not have authorized role`() {
-      webTestClient.post().uri("/api/bookings/mainOffence")
-        .headers(setClientAuthorisation(listOf()))
-        .header("Content-Type", APPLICATION_JSON_VALUE)
-        .bodyValue("[-1, -7]")
-        .exchange()
-        .expectStatus().isForbidden
-    }
-
-    @Test
-    fun offenceHistory_post() {
-      webTestClient.post().uri("/api/bookings/mainOffence")
-        .header("Content-Type", APPLICATION_JSON_VALUE)
-        .headers(setClientAuthorisation(listOf("ROLE_VIEW_PRISONER_DATA")))
-        .bodyValue("[-1, -7]")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody()
-        .jsonPath("length()").isEqualTo(3)
-        .jsonPath("[*].bookingId").value<List<Int>> { assertThat(it).containsOnly(-1, -7) }
-        .jsonPath("[0].offenceDescription").isEqualTo("Cause another to use a vehicle where the seat belt is not securely fastened to the anchorage point.")
-        .jsonPath("[1].offenceDescription").isEqualTo("Cause the carrying of a mascot etc on motor vehicle in position likely to cause injury")
-        .jsonPath("[2].offenceDescription").isEqualTo("Cause exceed max permitted wt of artic' vehicle - No of axles/configuration (No MOT/Manufacturer's Plate)")
-        .jsonPath("$[*].offenceCode").value<List<String>> { assertThat(it).containsExactlyElementsOf(listOf("RC86360", "RC86355", "RV98011")) }
-        .jsonPath("$[*].statuteCode").value<List<String>> { assertThat(it).containsOnly("RC86", "RV98") }
-    }
-
-    @Test
-    fun offenceHistory_post_no_offences() {
-      webTestClient.post().uri("/api/bookings/mainOffence")
-        .header("Content-Type", APPLICATION_JSON_VALUE)
-        .headers(setClientAuthorisation(listOf("ROLE_VIEW_PRISONER_DATA")))
-        .bodyValue("[-98, -99]")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody()
-        .jsonPath("length()").isEqualTo(0)
-    }
-  }
-
-  @Nested
   @DisplayName("GET /api/bookings/offenderNo/{offenderNo}/offenceHistory")
   inner class OffenderOffenceHistory {
 


### PR DESCRIPTION
There is still a `GET /api/bookings/{bookingId}/mainOffence` endpoint, but this one that takes multiple bookings is not used so can be removed.