### PR TITLE
ADJST-996: Add booking ids to imprisonment status

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/imprisonmentstatus/ImprisonmentStatusHistoryDto.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/imprisonmentstatus/ImprisonmentStatusHistoryDto.kt
@@ -15,4 +15,10 @@ data class ImprisonmentStatusHistoryDto(
 
   @Schema(description = "The agency the status was set by")
   val agencyId: String,
+
+  @Schema(description = "Booking Identifier (internal) the status is associated with", example = "12312312", required = true)
+  val bookingId: Long,
+
+  @Schema(description = "Book Number (Prison) / Prison Number (Probation) the status is associated with", example = "B45232", required = true)
+  val bookNumber: String,
 )

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/imprisonmentstatus/ImprisonmentStatusHistoryService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/imprisonmentstatus/ImprisonmentStatusHistoryService.kt
@@ -19,6 +19,8 @@ class ImprisonmentStatusHistoryService(
         status = it.imprisonmentStatus.status,
         effectiveDate = it.effectiveDate,
         agencyId = it.agyLocId,
+        bookingId = it.offenderBooking.bookingId,
+        bookNumber = it.offenderBooking.bookNumber,
       )
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/imprisonmentstatus/ImprisonmentStatusHistoryServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/imprisonmentstatus/ImprisonmentStatusHistoryServiceTest.kt
@@ -6,6 +6,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.justice.hmpps.prison.api.model.imprisonmentstatus.ImprisonmentStatusHistoryDto
 import uk.gov.justice.hmpps.prison.repository.jpa.model.ImprisonmentStatus
+import uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderBooking
 import uk.gov.justice.hmpps.prison.repository.jpa.model.OffenderImprisonmentStatus
 import uk.gov.justice.hmpps.prison.repository.jpa.repository.OffenderImprisonmentStatusRepository
 import java.time.LocalDate
@@ -25,28 +26,34 @@ class ImprisonmentStatusHistoryServiceTest {
     val recallStatus = ImprisonmentStatus().withStatus("LR")
     val firstDate = LocalDate.of(2024, 1, 1)
     val secondDate = LocalDate.of(2024, 2, 1)
+    val bookingOne = OffenderBooking().withBookingId(1L).withBookNumber("One")
+    val bookingTwo = OffenderBooking().withBookingId(2L).withBookNumber("Two")
     whenever(offenderImprisonmentStatusRepository.findByOffender(offenderId)).thenReturn(
       listOf(
         OffenderImprisonmentStatus()
           .withImprisonmentStatus(sentencedStatus)
           .withEffectiveDate(firstDate)
           .withImprisonStatusSeq(1)
-          .withAgyLocId("KMI"),
+          .withAgyLocId("KMI")
+          .withOffenderBooking(bookingOne),
         OffenderImprisonmentStatus()
           .withImprisonmentStatus(remandStatus)
           .withEffectiveDate(firstDate)
           .withImprisonStatusSeq(2)
-          .withAgyLocId("KMI"),
+          .withAgyLocId("KMI")
+          .withOffenderBooking(bookingOne),
         OffenderImprisonmentStatus()
           .withImprisonmentStatus(recallStatus)
           .withEffectiveDate(secondDate)
           .withImprisonStatusSeq(3)
-          .withAgyLocId("BMI"),
+          .withAgyLocId("BMI")
+          .withOffenderBooking(bookingTwo),
         OffenderImprisonmentStatus()
           .withImprisonmentStatus(sentencedStatus)
           .withEffectiveDate(secondDate)
           .withImprisonStatusSeq(4)
-          .withAgyLocId("BMI"),
+          .withAgyLocId("BMI")
+          .withOffenderBooking(bookingTwo),
       ),
     )
 
@@ -60,11 +67,15 @@ class ImprisonmentStatusHistoryServiceTest {
           status = "SEC38",
           effectiveDate = firstDate,
           agencyId = "KMI",
+          bookingId = 1L,
+          bookNumber = "One",
         ),
         ImprisonmentStatusHistoryDto(
           status = "ADIMP_ORA20",
           effectiveDate = secondDate,
           agencyId = "BMI",
+          bookingId = 2L,
+          bookNumber = "Two",
         ),
       ),
     )


### PR DESCRIPTION
Add bookingId and bookNumber to /api/imprisonment-status-history/{offenderNo}. This allows the identify remand tool to tell users where to go to fix issues with recall or remand imprisonment status changes, e.g. missing court events.