### PR TITLE
MAPA-316 Allow a cell swap destination on the standard cell move endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingMovementsResource.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/resource/BookingMovementsResource.java
@@ -26,7 +26,6 @@ import uk.gov.justice.hmpps.prison.api.model.CellMoveResult;
 import uk.gov.justice.hmpps.prison.api.model.CourtHearing;
 import uk.gov.justice.hmpps.prison.api.model.CourtHearings;
 import uk.gov.justice.hmpps.prison.api.model.ErrorResponse;
-import uk.gov.justice.hmpps.prison.api.model.OffenderBooking;
 import uk.gov.justice.hmpps.prison.api.model.PrisonToCourtHearing;
 import uk.gov.justice.hmpps.prison.api.model.RequestMoveToCellSwap;
 import uk.gov.justice.hmpps.prison.core.HasWriteScope;
@@ -89,7 +88,10 @@ public class BookingMovementsResource {
         @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "423", description = "Record in use for this booking id (possibly in P-Nomis).", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
-    @Operation(summary = "Move Offender to another cell or reception")
+    @Operation(
+        summary = "Move Offender to another cell, reception or cell swap",
+        description = "Pass the destination's description. For a cell swap this is the prison's CSWAP location, described PRISON_ID-CSWAP - for example LEI-CSWAP. A cell swap destination is exempt from the capacity check, since cell swap is deliberately uncapped."
+    )
     @PutMapping("/{bookingId}/living-unit/{internalLocationDescription}")
     @ProxyUser
     @VerifyBookingAccess(overrideRoles = {"MAINTAIN_CELL_MOVEMENTS"})
@@ -111,14 +113,16 @@ public class BookingMovementsResource {
     }
 
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "OK", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = OffenderBooking.class))}),
+        @ApiResponse(responseCode = "200", description = "OK", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = CellMoveResult.class))}),
         @ApiResponse(responseCode = "400", description = "Invalid request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "404", description = "Requested resource not found.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
         @ApiResponse(responseCode = "500", description = "Unrecoverable error occurred whilst processing request.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})})
     @PutMapping("/{bookingId}/move-to-cell-swap")
     @Operation(
-        summary = "Move the prisoner from current cell to cell swap",
-        description = "Using role MAINTAIN_CELL_MOVEMENTS will no longer check for user access to prisoner booking, this endpoint will be removed in future releases"
+        summary = "Move the prisoner from current cell to cell swap (deprecated)",
+        deprecated = true,
+        description = "Using role MAINTAIN_CELL_MOVEMENTS will no longer check for user access to prisoner booking, this endpoint will be removed in future releases. " +
+            "Use PUT /api/bookings/{bookingId}/living-unit/{internalLocationDescription} instead, passing the prison's cell swap location as the description - PRISON_ID-CSWAP, for example LEI-CSWAP."
     )
     @ProxyUser
     @Deprecated

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/MovementUpdateService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/MovementUpdateService.java
@@ -54,7 +54,14 @@ public class MovementUpdateService {
             return transformToCellSwapResult(offenderBooking);
         }
 
-        if (internalLocation.isActiveCellWithSpace() || internalLocation.isActiveReceptionWithSpace()) {
+        // A cell swap location is checked first and on its own: it is a WING rather than a CELL and is
+        // deliberately uncapped, so it satisfies neither of the checks below. Short-circuiting here is
+        // what lets this endpoint serve the cell swap that move-to-cell-swap was added for.
+        // BookingService.validateUpdateLivingUnit already exempts cell swap from its own type check,
+        // and still applies the same-prison check.
+        if (internalLocation.isCellSwap()
+                || internalLocation.isActiveCellWithSpace()
+                || internalLocation.isActiveReceptionWithSpace()) {
             return saveAndReturnInternalMoveResult(bookingId, reasonCode, movementDateTime, internalLocation, lockTimeout);
         }
         throw new IllegalArgumentException(String.format("Location %s is either not a cell or reception, active or is at maximum capacity", internalLocation.getDescription()));

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingMovementsResourceIntTest_moveToCell.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/BookingMovementsResourceIntTest_moveToCell.kt
@@ -139,6 +139,28 @@ class BookingMovementsResourceIntTest_moveToCell : ResourceTest() {
   }
 
   @Test
+  fun cellSwapLocation_movesToCellSwap() {
+    // The cell swap location is a WING and is uncapped, so it satisfies neither of the cell/reception
+    // checks. This endpoint accepts it anyway, which is what allows the deprecated
+    // PUT /api/bookings/{bookingId}/move-to-cell-swap to be retired.
+    val dateTime = LocalDateTime.now().minusHours(1)
+
+    val response: ResponseEntity<String> = requestMoveToCell(
+      validToken(),
+      BOOKING_ID_S,
+      CELL_SWAP_DESC,
+      "ADM",
+      dateTime.format(
+        DateTimeFormatter.ISO_LOCAL_DATE_TIME,
+      ),
+    )
+
+    verifySuccessResponse(response, BOOKING_ID, CELL_SWAP, CELL_SWAP_DESC)
+    verifyOffenderBookingLivingUnit(BOOKING_ID, CELL_SWAP)
+    verifyLastBedAssignmentHistory(BOOKING_ID, CELL_SWAP, "ADM", dateTime)
+  }
+
+  @Test
   fun notFound() {
     val dateTime = LocalDateTime.now().minusHours(1)
     val invalidBookingId = "-69854"
@@ -393,5 +415,8 @@ class BookingMovementsResourceIntTest_moveToCell : ResourceTest() {
     private val NEW_CELL = -18L
     private const val NEW_CELL_DESC = "LEI-H-1-4"
     private const val CELL_DIFF_PRISON_S = "MDI-1-1-001"
+
+    private val CELL_SWAP = 14538L
+    private const val CELL_SWAP_DESC = "LEI-CSWAP"
   }
 }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/MovementUpdateServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/MovementUpdateServiceTest.kt
@@ -282,6 +282,36 @@ internal class MovementUpdateServiceTest {
     }
 
     @Test
+    fun updatesBookingCellSwap() {
+      mockSuccessForCellSwap()
+
+      service.moveToCellOrReception(SOME_BOOKING_ID, NEW_CELL_SWAP_DESC, SOME_REASON_CODE, SOME_TIME, false)
+
+      verify(bookingService).updateLivingUnit(
+        SOME_BOOKING_ID,
+        cellSwapDestination().get(),
+        false,
+      )
+      verify(bedAssignmentHistoryService)
+        .add(SOME_BOOKING_ID, CELL_SWAP_LOCATION_ID, SOME_REASON_CODE, SOME_TIME)
+    }
+
+    @Test
+    fun cellSwapAtCapacity_stillMoves() {
+      // Cell swap is deliberately uncapped. The gate short-circuits on isCellSwap() before reaching
+      // hasSpace(), so a CSWAP location recorded as full must still accept the move.
+      mockSuccessForCellSwap(fullCellSwapDestination())
+
+      service.moveToCellOrReception(SOME_BOOKING_ID, NEW_CELL_SWAP_DESC, SOME_REASON_CODE, SOME_TIME, false)
+
+      verify(bookingService).updateLivingUnit(
+        SOME_BOOKING_ID,
+        fullCellSwapDestination().get(),
+        false,
+      )
+    }
+
+    @Test
     fun writesToBedAssignmentHistories() {
       mockSuccess()
 
@@ -399,6 +429,26 @@ internal class MovementUpdateServiceTest {
         ),
       )
         .thenReturn(receptionLocation(NEW_LIVING_UNIT_ID, RECEPTION_CODE))
+    }
+
+    private fun mockSuccessForCellSwap(destination: Optional<AgencyInternalLocation> = cellSwapDestination()) {
+      whenever(
+        referenceDomainService.getReferenceCodeByDomainAndCode(
+          anyString(),
+          anyString(),
+          eq(false),
+        ),
+      )
+        .thenReturn(Optional.of(mock(ReferenceCode::class.java)))
+      whenever(offenderBookingRepository.findById(anyLong()))
+        .thenReturn(anOffenderBooking(SOME_BOOKING_ID, SOME_AGENCY_ID, OLD_LIVING_UNIT_ID, OLD_LIVING_UNIT_DESC, true))
+        .thenReturn(anOffenderBooking(SOME_BOOKING_ID, SOME_AGENCY_ID, CELL_SWAP_LOCATION_ID, NEW_CELL_SWAP_DESC, true))
+      whenever(
+        agencyInternalLocationRepository.findOneByDescription(
+          NEW_CELL_SWAP_DESC,
+        ),
+      )
+        .thenReturn(destination)
     }
 
     private fun mockCellNotChanged() {
@@ -712,6 +762,35 @@ internal class MovementUpdateServiceTest {
     )
   }
 
+  /**
+   * A prison's cell swap location as it really is in NOMIS: a WING, uncertified, with no parent and
+   * location code CSWAP - so it satisfies isCellSwap() but neither isActiveCellWithSpace() nor
+   * isActiveReceptionWithSpace().
+   */
+  private fun cellSwapDestination(): Optional<AgencyInternalLocation> = Optional.of(
+    AgencyInternalLocation.builder()
+      .locationId(CELL_SWAP_LOCATION_ID)
+      .locationCode(CELL_SWAP_LOCATION_CODE)
+      .description(NEW_CELL_SWAP_DESC)
+      .locationType("WING")
+      .certifiedFlag(false)
+      .active(true)
+      .build(),
+  )
+
+  private fun fullCellSwapDestination(): Optional<AgencyInternalLocation> = Optional.of(
+    AgencyInternalLocation.builder()
+      .locationId(CELL_SWAP_LOCATION_ID)
+      .locationCode(CELL_SWAP_LOCATION_CODE)
+      .description(NEW_CELL_SWAP_DESC)
+      .locationType("WING")
+      .certifiedFlag(false)
+      .active(true)
+      .capacity(2)
+      .currentOccupancy(2)
+      .build(),
+  )
+
   private fun aLocation(locationId: Long?, locationCode: String?): Optional<AgencyInternalLocation> = Optional.of(
     AgencyInternalLocation.builder()
       .locationId(locationId)
@@ -751,6 +830,10 @@ internal class MovementUpdateServiceTest {
     private const val SOME_REASON_CODE = "ADM"
     private const val CELL_SWAP_LOCATION_CODE = "CSWAP"
     private const val CELL_SWAP_LOCATION_DESCRIPTION = "LEI-CSWAP"
+
+    // The bookings in these tests are at MDI, and moveToCellOrReception resolves by description,
+    // so it needs MDI's own cell swap location rather than the LEI one above.
+    private const val NEW_CELL_SWAP_DESC = "MDI-CSWAP"
     private const val CELL_SWAP_LOCATION_ID = 123L
 
     private val clock: Clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())


### PR DESCRIPTION
**Additive only. No existing move changes behaviour, and the deprecated endpoint is untouched.**

## Why

`PUT /api/bookings/{bookingId}/move-to-cell-swap` is marked `@Deprecated` — *"this endpoint will be removed in future releases"* — but it can't go while the standard cell move endpoint refuses the one destination it exists to serve. Callers can't leave it, so it can't be removed. This unblocks that.

## The change

`MovementUpdateService.moveToCellOrReception` gated on `isActiveCellWithSpace() || isActiveReceptionWithSpace()`. A cell swap location satisfies neither — it's a `WING` rather than a `CELL` (`R__3_2__AGENCY_INTERNAL_LOCATIONS.sql:110`) and it's deliberately uncapped — so the request was rejected with a 400 before reaching code that handles it perfectly well.

`BookingService.validateUpdateLivingUnit` has exempted cell swap from its own type check all along:

```java
if (!location.isCellSwap()) {
    checkArgument(location.isCell() || location.isReception(), ...);
}
```

Only the outer gate needed to move. `isCellSwap()` goes first so it short-circuits the capacity check — that's deliberate and preserves today's behaviour, since cell swap has never been capacity limited.

The same-prison check in `validateUpdateLivingUnit` still applies, so a cell swap location in another prison is still refused. Nothing mutates occupancy on a move, so a CSWAP row with null occupancy is safe.

The two lookups already meet: cell swap descriptions are `{prisonId}-CSWAP`, asserted as `LEI-CSWAP` in `AgencyInternalLocationsRepositoryTest.kt:46-48`, so `findOneByDescription` resolves it with no new field and no new lookup.

## Also in here (documentation only)

- The cell swap endpoint's `@ApiResponse` documented a 200 of `OffenderBooking`; the method returns `CellMoveResult`. Corrected.
- Its deprecation notice now names the replacement, so anyone reading the docs during the deprecation window is told where to go.
- The living-unit endpoint's summary mentions cell swap, so the new capability is discoverable.

## Testing

`./gradlew assemble check` — 2,343 pass. `./gradlew testIntegration` — 1,586 pass.

New coverage:
- `MovementUpdateServiceTest.updatesBookingCellSwap` — moves the booking and writes the bed assignment history row.
- `MovementUpdateServiceTest.cellSwapAtCapacity_stillMoves` — a CSWAP location recorded as full still accepts the move, proving the gate short-circuits rather than falling through to `hasSpace()`.
- `BookingMovementsResourceIntTest_moveToCell.cellSwapLocation_movesToCellSwap` — end to end against `LEI-CSWAP`.

Existing coverage kept as the regression proof that the gate hasn't been weakened for ordinary moves: `noCapacity_throwsException`, `locationTypeNotACell_badRequest` and `locationFull_badRequest` all still pass unchanged, as do all the `move-to-cell-swap` tests.

## What follows

Not in this PR: `hmpps-change-someones-cell-api` — the only live caller of `move-to-cell-swap` — switches to this endpoint once this is released, and the deprecated endpoint can be deleted after that has run in production. Tracked as MAPA-316.