### PR TITLE
MAPA-316 Correct the cell swap comment about location type

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/service/MovementUpdateService.java
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/MovementUpdateService.java
@@ -54,9 +54,11 @@ public class MovementUpdateService {
             return transformToCellSwapResult(offenderBooking);
         }
 
-        // A cell swap location is checked first and on its own: it is a WING rather than a CELL and is
-        // deliberately uncapped, so it satisfies neither of the checks below. Short-circuiting here is
-        // what lets this endpoint serve the cell swap that move-to-cell-swap was added for.
+        // A cell swap location is checked first and on its own: it is neither a cell nor a reception,
+        // and it is deliberately uncapped, so it satisfies neither of the checks below.
+        // Short-circuiting here is what lets this endpoint serve the cell swap that move-to-cell-swap
+        // was added for. Note isCellSwap() deliberately ignores locationType - across the live estate
+        // these locations are recorded as WING, HOLD and AREA - so do not narrow this to a type.
         // BookingService.validateUpdateLivingUnit already exempts cell swap from its own type check,
         // and still applies the same-prison check.
         if (internalLocation.isCellSwap()

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/MovementUpdateServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/MovementUpdateServiceTest.kt
@@ -763,9 +763,12 @@ internal class MovementUpdateServiceTest {
   }
 
   /**
-   * A prison's cell swap location as it really is in NOMIS: a WING, uncertified, with no parent and
-   * location code CSWAP - so it satisfies isCellSwap() but neither isActiveCellWithSpace() nor
+   * A prison's cell swap location as it really is in NOMIS: uncertified, with no parent and location
+   * code CSWAP - so it satisfies isCellSwap() but neither isActiveCellWithSpace() nor
    * isActiveReceptionWithSpace().
+   *
+   * locationType is incidental. It is WING here to match the seed data, but across the live estate
+   * these locations are recorded as WING, HOLD and AREA, and isCellSwap() does not look at it.
    */
   private fun cellSwapDestination(): Optional<AgencyInternalLocation> = Optional.of(
     AgencyInternalLocation.builder()


### PR DESCRIPTION
**Comment-only. No behaviour change.**

Follow-up to #2722. The comment I added there says a cell swap location *"is a WING rather than a CELL"*. That's true of the test seed data (`R__3_2__AGENCY_INTERNAL_LOCATIONS.sql:110`) but not of the live estate.

Sweeping all 127 prisons in production — via `GET /api/locations/code/{prisonId}-CSWAP`, which uses the same `findOneByDescription` lookup the cell move performs — these locations turn out to be recorded as **WING, HOLD and AREA**.

The gate has always been correct for all of them, because `isCellSwap()` never looked at `locationType`:

```java
public boolean isCellSwap() {
    return !isCertifiedFlag() && isActive() && parentLocation == null
            && locationCode != null && locationCode.equals("CSWAP");
}
```

So nothing changes except the comment — but it's the kind that invites someone to "tighten" the check to `locationType.equals("WING")` later and break a hundred prisons. It now says so explicitly, in `MovementUpdateService` and in the test helper that builds the fixture.

`./gradlew ktlintCheck` and `MovementUpdateServiceTest` (25 tests) pass.

MAPA-316