### PR TITLE
MAPA-317 Add mainOffence to the prisoner-search feed

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/MainOffence.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/MainOffence.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.hmpps.prison.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "The main offence of a booking")
+data class MainOffence(
+  @Schema(description = "Offence code, from OFFENDER_CHARGES", example = "RR84070")
+  val offenceCode: String?,
+
+  @Schema(description = "Description of the offence", example = "Actual bodily harm")
+  val offenceDescription: String?,
+)

--- a/src/main/java/uk/gov/justice/hmpps/prison/api/model/PrisonerSearchDetails.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/api/model/PrisonerSearchDetails.kt
@@ -81,6 +81,13 @@ data class PrisonerSearchDetails(
   @Schema(description = "Most serious offence")
   val mostSeriousOffence: String? = null,
 
+  @Schema(
+    description = "The main offence of the active booking: the most serious active charge, whether or not it has " +
+      "resulted in a conviction. Unlike mostSeriousOffence this is populated for a prisoner without a conviction, " +
+      "such as someone on remand.",
+  )
+  val mainOffence: MainOffence? = null,
+
   @Schema(description = "Currently serving an indeterminate sentence?")
   val indeterminateSentence: Boolean? = null,
 

--- a/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.prison.service
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Component
 import uk.gov.justice.hmpps.prison.api.model.InmateDetail
+import uk.gov.justice.hmpps.prison.api.model.MainOffence
 import uk.gov.justice.hmpps.prison.api.model.OffenderLanguageDto
 import uk.gov.justice.hmpps.prison.api.model.PrisonerSearchDetails
 import uk.gov.justice.hmpps.prison.repository.jpa.model.ExternalMovement
@@ -24,6 +25,7 @@ class PrisonerSearchService(
   private val offenderRepository: OffenderRepository,
   private val offenderTransformer: OffenderTransformer,
   private val inmateService: InmateService,
+  private val bookingService: BookingService,
   private val healthService: HealthService,
   private val offenderLanguageRepository: OffenderLanguageRepository,
 ) {
@@ -62,6 +64,7 @@ class PrisonerSearchService(
           allIdentifiers = offender.allIdentifiers?.map { oi -> oi.toModel(detail.offenderNo) }?.sortedBy { it.whenCreated },
           sentenceDetail = detail.sentenceDetail?.apply { additionalDaysAwarded = booking?.additionalDaysAwarded },
           mostSeriousOffence = detail.offenceHistory?.filter { off -> off.bookingId == detail.bookingId }?.filter { it.mostSerious }?.minByOrNull { it.offenceSeverityRanking }?.offenceDescription,
+          mainOffence = findMainOffence(detail.bookingId),
           indeterminateSentence = detail.sentenceTerms?.any { st -> st.lifeSentence && detail.bookingId == st.bookingId },
           aliases = detail.aliases,
           status = detail.status,
@@ -119,6 +122,22 @@ class PrisonerSearchService(
           )
         }
     }
+
+  /**
+   * The main offence of the booking: the most serious active charge, convicted or not.
+   *
+   * [PrisonerSearchDetails.mostSeriousOffence] comes from [InmateDetail.offenceHistory], which
+   * InmateService builds with `convictionsOnly = true`, so anyone without a conviction - every
+   * remand prisoner, and immigration detainees - has no offence there at all. NOMIS does hold one
+   * for them: it maintains `OFFENDER_CHARGES.MOST_SERIOUS_FLAG` whenever a charge or a sentence
+   * changes. This reads that instead, which is the same source `GET /api/bookings/{bookingId}/mainOffence`
+   * serves, so the two always agree.
+   *
+   * `getMainOffenceDetails` orders by offence severity ranking, so the first row is the most serious.
+   */
+  private fun findMainOffence(bookingId: Long?): MainOffence? = bookingId
+    ?.let { bookingService.getMainOffenceDetails(it).firstOrNull() }
+    ?.let { MainOffence(offenceCode = it.offenceCode, offenceDescription = it.offenceDescription) }
 
   private fun findLastMovementTime(
     externalMovements: List<ExternalMovement>?,

--- a/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/api/resource/impl/PrisonerSearchResourceIntTest.kt
@@ -133,7 +133,14 @@ class PrisonerSearchResourceIntTest : ResourceTest() {
               assertThat(releaseDate).isEqualTo("2018-04-19")
             }
             assertThat(sentenceDetail?.additionalDaysAwarded).isNull()
+            // Booking -2 is the unsentenced case: an active MOST_SERIOUS_FLAG='Y' charge but no
+            // conviction result, so offenceHistory - which is convictions-only - is empty and
+            // mostSeriousOffence stays null, while mainOffence reads the charge itself.
             assertThat(mostSeriousOffence).isNull()
+            with(mainOffence!!) {
+              assertThat(offenceCode).isEqualTo("M1")
+              assertThat(offenceDescription).isEqualTo("Actual bodily harm")
+            }
             assertThat(indeterminateSentence).isTrue()
             assertThat(aliases).isEmpty()
             assertThat(status).isEqualTo("ACTIVE IN")
@@ -215,7 +222,10 @@ class PrisonerSearchResourceIntTest : ResourceTest() {
                 tuple("PNC", "24/1234567L", "A1234AC", LocalDate.parse("2024-01-01"), "INST"),
               )
             assertThat(identifiers?.first()?.whenCreated?.toLocalDate()).isEqualTo(LocalDate.now())
+            // Booking -3 has charges, but both are MOST_SERIOUS_FLAG='N', so there is no main
+            // offence to report and both fields are legitimately null.
             assertThat(mostSeriousOffence).isNull()
+            assertThat(mainOffence).isNull()
             assertThat(aliases).isEmpty()
             assertThat(militaryRecord).isFalse()
           }
@@ -313,6 +323,19 @@ class PrisonerSearchResourceIntTest : ResourceTest() {
         .consumeWith { response ->
           with(response.responseBody!!) {
             assertThat(mostSeriousOffence).isEqualTo("Cause exceed max permitted wt of artic' vehicle - No of axles/configuration (No MOT/Manufacturer's Plate)")
+          }
+        }
+    }
+
+    @Test
+    fun `should return the main offence, agreeing with most serious offence where the prisoner is sentenced`() {
+      webTestClient.getPrisonerSearchDetails("A1234AA")
+        .consumeWith { response ->
+          with(response.responseBody!!) {
+            with(mainOffence!!) {
+              assertThat(offenceCode).isEqualTo("RV98011")
+              assertThat(offenceDescription).isEqualTo(mostSeriousOffence)
+            }
           }
         }
     }

--- a/src/test/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/prison/service/PrisonerSearchServiceTest.kt
@@ -21,6 +21,7 @@ class PrisonerSearchServiceTest {
   private val offenderRepository: OffenderRepository = mock()
   private val offenderTransformer: OffenderTransformer = mock()
   private val inmateService: InmateService = mock()
+  private val bookingService: BookingService = mock()
   private val healthService: HealthService = mock()
   private val offenderLanguageRepository: OffenderLanguageRepository = mock()
 
@@ -29,6 +30,7 @@ class PrisonerSearchServiceTest {
     offenderRepository,
     offenderTransformer,
     inmateService,
+    bookingService,
     healthService,
     offenderLanguageRepository,
   )


### PR DESCRIPTION
Adds a new `mainOffence` field to `GET /api/prisoner-search/offenders/{offenderNo}`. **`mostSeriousOffence` is not touched.**

This is raised by the Prisoner Cell Allocation team (MAPA-317) rather than by Syscon — we hit the gap, so we have written the change for you to judge. Happy to hand it over or close it if you would rather do this differently.

## The problem

`mostSeriousOffence` is null for every prisoner without a conviction — everyone on remand, plus immigration detainees.

In a 160-prisoner production sample that was **29% of the population**. In a remand-only sample it was **0 of 25**, where this API's own `GET /api/bookings/{bookingId}/mainOffence` returned a real offence for **24 of those 25**.

The cause is a filter, not missing data. `PrisonerSearchService` derives the field from `InmateDetail.offenceHistory`, which `InmateService.java:257` builds by calling `getActiveOffencesForBooking(bookingId, true)` — `convictionsOnly = true`. `SentenceRepositorySql.GET_OFFENCES_FOR_BOOKING` then requires `ORC1.CONVICTION_FLAG = 'Y' OR ORC2.CONVICTION_FLAG = 'Y'`, so a prisoner with no conviction result has an empty list.

Andy Marke confirmed NOMIS maintains a main offence for remand prisoners regardless of sentencing, recalculated whenever a charge or a sentence changes. That is `OFFENDER_CHARGES.MOST_SERIOUS_FLAG`, which `GET_BOOKING_MAIN_OFFENCES` reads with no conviction filter. The data is there; the prisoner-search feed just never carried it.

## Why a new field rather than fixing the old one

An earlier version of this PR made `mostSeriousOffence` fall back to the charge-based offence. We withdrew that.

Filling a null changes what the field means to everyone reading it. A consumer treating `mostSeriousOffence == null` as a proxy for "not sentenced" would silently break, and we have no way to know who does that. So this version leaves it exactly as it is:

- **Nothing already populated changes.** Purely additive.
- No existing consumer can regress.

## The change

```json
"mainOffence": { "offenceCode": "M1", "offenceDescription": "Actual bodily harm" }
```

`findMainOffence` reuses `BookingService.getMainOffenceDetails(bookingId)` rather than adding a query, so the value is by construction the same one `GET /api/bookings/{bookingId}/mainOffence` serves. That SQL orders by `OFFS.SEVERITY_RANKING`, so the first row is the most serious. `statuteCode` and `bookingId` from that model are deliberately dropped — the consumer needs neither.

## Two things worth your judgement

1. **The two fields agree where both exist.** In 20 of 20 sampled convicted prisoners, `mostSeriousOffence` was identical to `mainOffence`, character for character. The new field is consistent with the old one, not a competing answer.

2. **Consumer side.** The matching hmpps-prisoner-search PR is ministryofjustice/hmpps-prisoner-search#813. This one should reach **prod** before that is deployed, otherwise the indexer reads a field that is not being served yet.

## Tests

`PrisonerSearchResourceIntTest` now pins all three cases against existing fixtures:

- **`A1234AB`** (booking `-2`) — the unsentenced case. An active `MOST_SERIOUS_FLAG='Y'` charge with no conviction result: `mostSeriousOffence` stays null, `mainOffence` is populated.
- **`A1234AC`** (booking `-3`) — both charges `MOST_SERIOUS_FLAG='N'`, so both fields are legitimately null.
- **`A1234AA`** (booking `-1`) — sentenced, and asserts the two fields agree.
